### PR TITLE
Use `aird.Diagram`'s `.calculate_viewport`

### DIFF
--- a/capellambse_context_diagrams/collectors/__init__.py
+++ b/capellambse_context_diagrams/collectors/__init__.py
@@ -21,8 +21,7 @@ logger = logging.getLogger(__name__)
 def get_elkdata(
     diagram: context.ContextDiagram, params: dict[str, t.Any] | None = None
 ) -> _elkjs.ELKInputData:
-    """
-    High level collector function to collect needed data for ELK
+    """High level collector function to collect needed data for ELK.
 
     Parameters
     ----------

--- a/capellambse_context_diagrams/collectors/exchanges.py
+++ b/capellambse_context_diagrams/collectors/exchanges.py
@@ -133,7 +133,7 @@ def get_elkdata_for_exchanges(
     collector_type: type[ExchangeCollector],
 ) -> _elkjs.ELKInputData:
     """Return exchange data for ELK."""
-    data = generic.collector(diagram)
+    data = makers.make_diagram(diagram)
     collector = collector_type(diagram, data)
     data["edges"] = collector.collect()
     for comp in data["children"]:
@@ -161,7 +161,6 @@ class InterfaceContextCollector(ExchangeCollector):
         data: _elkjs.ELKInputData,
     ) -> None:
         super().__init__(diagram, data)
-        self.data["children"] = []
         self.get_left_and_right()
 
     def get_left_and_right(self) -> None:
@@ -177,7 +176,7 @@ class InterfaceContextCollector(ExchangeCollector):
             comp: common.GenericElement, functions: list[common.GenericElement]
         ) -> None:
             if comp.uuid not in made_children:
-                box = makers.make_box(comp)
+                box = makers.make_box(comp, no_symbol=True)
                 box["children"] = [
                     makers.make_box(c)
                     for c in functions

--- a/capellambse_context_diagrams/collectors/generic.py
+++ b/capellambse_context_diagrams/collectors/generic.py
@@ -40,15 +40,12 @@ def collector(
     width: int | float = makers.EOI_WIDTH,
     no_symbol: bool = False,
 ) -> _elkjs.ELKInputData:
-    """Returns `ELKInputData` with only centerbox in children and config."""
-    return {
-        "id": diagram.uuid,
-        "layoutOptions": _elkjs.get_global_layered_layout_options(),
-        "children": [
-            makers.make_box(diagram.target, width=width, no_symbol=no_symbol)
-        ],
-        "edges": [],
-    }
+    """Returns ``ELKInputData`` with only centerbox in children and config."""
+    data = makers.make_diagram(diagram)
+    data["children"] = [
+        makers.make_box(diagram.target, width=width, no_symbol=no_symbol)
+    ]
+    return data
 
 
 def collect_exchange_endpoints(

--- a/capellambse_context_diagrams/collectors/makers.py
+++ b/capellambse_context_diagrams/collectors/makers.py
@@ -7,7 +7,7 @@ from capellambse import helpers
 from capellambse.model import common, layers
 from capellambse.svg.decorations import icon_padding, icon_size
 
-from .. import _elkjs
+from .. import _elkjs, context
 
 PORT_SIZE = 10
 """Default size of ports in pixels."""
@@ -15,7 +15,7 @@ PORT_PADDING = 2
 """Default padding of ports in pixels."""
 LABEL_HPAD = 15
 """Horizontal padding left and right of the label."""
-LABEL_VPAD = 5
+LABEL_VPAD = 1
 """Vertical padding above and below the label."""
 NEIGHBOR_VMARGIN = 20
 """Vertical space between two neighboring boxes."""
@@ -43,6 +43,16 @@ BOX_TO_SYMBOL = (
 Types that need to be converted to symbols during serialization if
 `display_symbols_as_boxes` attribute is `False`.
 """
+
+
+def make_diagram(diagram: context.ContextDiagram) -> _elkjs.ELKInputData:
+    """Return basic skeleton for ``ContextDiagram``s."""
+    return {
+        "id": diagram.uuid,
+        "layoutOptions": _elkjs.get_global_layered_layout_options(),
+        "children": [],
+        "edges": [],
+    }
 
 
 def make_box(
@@ -90,6 +100,7 @@ def make_label(obj: common.GenericElement) -> _elkjs.ELKInputLabel:
         "text": obj.name,
         "width": label_width + 2 * LABEL_HPAD,
         "height": label_height + 2 * LABEL_VPAD,
+        "layoutOptions": {"nodeLabels.placement": "INSIDE, V_TOP, H_CENTER"},
     }
 
 

--- a/capellambse_context_diagrams/serializers.py
+++ b/capellambse_context_diagrams/serializers.py
@@ -11,9 +11,8 @@ from __future__ import annotations
 
 import logging
 
-from capellambse import aird, helpers
+from capellambse import aird
 from capellambse.model import common
-from capellambse.svg.decorations import icon_padding, icon_size
 
 from . import _elkjs, collectors, context
 
@@ -70,10 +69,6 @@ class DiagramSerializer:
         )
         for child in data["children"]:
             self.deserialize_child(child, aird.Vector2D(), None)
-
-        for element in self._cache.values():
-            if element.JSON_TYPE == "box":
-                self.check_boxlabel_space(element)
 
         self.aird_diagram.calculate_viewport()
         return self.aird_diagram
@@ -225,41 +220,6 @@ class DiagramSerializer:
 
             styleoverrides = style_condition(obj)
         return styleoverrides
-
-    def check_boxlabel_space(self, box: aird.Box) -> None:
-        """Check if size of parent boxes is enough for their label."""
-        if not box.children or any(child.port for child in box.children):
-            return
-
-        child_dist = min(
-            [
-                abs(child.pos.y - box.pos.y)
-                for child in box.children
-                if isinstance(child, aird.Box)
-            ]
-        )
-
-        label = box.label
-        if isinstance(label, aird.Box):
-            label = label.label
-        elif label is None:
-            return
-
-        assert isinstance(label, str)
-        lines = helpers.word_wrap(
-            label, box.size.x - (2 * icon_padding + icon_size)
-        )
-        _, labelheight = helpers.extent_func(label)
-        labelspace = aird.Vector2D(
-            0,
-            child_dist
-            - (2 * collectors.makers.LABEL_VPAD + len(lines) * labelheight),
-        )
-        if labelspace.y >= 0:
-            return
-
-        box.pos += labelspace
-        box.size += abs(labelspace)
 
 
 def get_styleclass(obj: common.GenericElement) -> str:

--- a/tests/test_context_diagrams.py
+++ b/tests/test_context_diagrams.py
@@ -81,9 +81,9 @@ def test_context_diagrams(
         ),
         pytest.param(
             [
-                ("6241d0c5-65d2-4c0b-b79c-a2a8ed7273f6", 20),
-                ("344a405e-c7e5-4367-8a9a-41d3d9a27f81", 20),
-                ("230c4621-7e0a-4d0a-9db2-d4ba5e97b3df", 45),
+                ("6241d0c5-65d2-4c0b-b79c-a2a8ed7273f6", 17),
+                ("344a405e-c7e5-4367-8a9a-41d3d9a27f81", 17),
+                ("230c4621-7e0a-4d0a-9db2-d4ba5e97b3df", 38),
             ],
             id="SystemComponent Root",
         ),


### PR DESCRIPTION
All space-checker methods were removed by using `aird.Diagram`'s own viewport calculation functionality and a hidden implicit box sizing feature of ELK. In the latter children or labels with sizes (width and height information) make any size information on the parent useless. We used this behaviour to get enough space for big labels in boxes such that adjustments aren't needed anymore. Since we are not patching any sizes of diagram elements anymore we don't risk overlaps anymore. Kudos to @Wuestengecko.