### PR TITLE
Reduce minimum size for py3.9-windows test

### DIFF
--- a/tests/test_context_diagrams.py
+++ b/tests/test_context_diagrams.py
@@ -83,7 +83,7 @@ def test_context_diagrams(
             [
                 ("6241d0c5-65d2-4c0b-b79c-a2a8ed7273f6", 17),
                 ("344a405e-c7e5-4367-8a9a-41d3d9a27f81", 17),
-                ("230c4621-7e0a-4d0a-9db2-d4ba5e97b3df", 38),
+                ("230c4621-7e0a-4d0a-9db2-d4ba5e97b3df", 37),
             ],
             id="SystemComponent Root",
         ),


### PR DESCRIPTION
This fixes broken Python3.9 windows workflow.