### PR TITLE
Fix exchange collection for portless diagrams

### DIFF
--- a/capellambse_context_diagrams/collectors/default.py
+++ b/capellambse_context_diagrams/collectors/default.py
@@ -98,7 +98,7 @@ def port_collector(
 def port_exchange_collector(
     ports: t.Iterable[common.GenericElement],
 ) -> list[common.GenericElement]:
-    """Savely collect exchanges from `ports`."""
+    """Collect exchanges from `ports` savely."""
     exchanges: list[common.GenericElement] = []
     for i in ports:
         try:

--- a/capellambse_context_diagrams/collectors/portless.py
+++ b/capellambse_context_diagrams/collectors/portless.py
@@ -150,8 +150,8 @@ def get_exchanges(
 ) -> t.Iterator[common.GenericElement]:
     """Yield exchanges safely.
 
-    Yields exchanges from `.exchanges` or `.extends`, `.includes` and
-    `.inheritance` (exclusively for Capabilities).
+    Yields exchanges from `.related_exchanges` or `.extends`,
+    `.includes` and `.inheritance` (exclusively for Capabilities).
     """
     is_op_capability = isinstance(obj, layers.oa.OperationalCapability)
     is_capability = isinstance(obj, layers.ctx.Capability)
@@ -160,7 +160,7 @@ def get_exchanges(
     elif isinstance(obj, layers.ctx.Mission):
         exchanges = obj.involvements + obj.exploitations
     else:
-        exchanges = obj.exchanges
+        exchanges = obj.related_exchanges
 
     if is_op_capability:
         exchanges += obj.entity_involvements


### PR DESCRIPTION
The `.exchanges` attribute was renamed to `.related_exchanges` in v.0.5.1 of py-capellambse.