### PR TITLE
Add physical component context

### DIFF
--- a/capellambse_context_diagrams/collectors/generic.py
+++ b/capellambse_context_diagrams/collectors/generic.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 SourceAndTarget = tuple[common.GenericElement, common.GenericElement]
 
 
-CONNECTOR_ATTR_NAMES = {"inputs", "outputs"}
+CONNECTOR_ATTR_NAMES = {"inputs", "outputs", "physical_ports"}
 """Attribute of GenericElements for receiving connections."""
 PORTLESS_DIAGRAM_TYPES = {DT.OAB, DT.OAIB, DT.OCB, DT.MCB}
 """Supported diagram types without connectors (i.e. ports)."""

--- a/capellambse_context_diagrams/serializers.py
+++ b/capellambse_context_diagrams/serializers.py
@@ -236,6 +236,7 @@ def get_styleclass(obj: common.GenericElement) -> str:
             (
                 styleclass[: -len("Component")],
                 "Human" * obj.is_human,
+                obj.nature.name.capitalize() if hasattr(obj, "nature") else "",
                 ("Component", "Actor")[obj.is_actor],
             )
         )

--- a/tests/test_context_diagrams.py
+++ b/tests/test_context_diagrams.py
@@ -31,6 +31,13 @@ TEST_ACTOR_SIZING_UUID = "6c8f32bf-0316-477f-a23b-b5239624c28d"
         pytest.param(
             "7f138bae-4949-40a1-9a88-15941f827f8c", id="LogicalFunction"
         ),
+        pytest.param(
+            "b51ccc6f-5f96-4e28-b90e-72463a3b50cf", id="PhysicalNodeComponent"
+        ),
+        pytest.param(
+            "c78b5d7c-be0c-4ed4-9d12-d447cb39304e",
+            id="PhysicalBehaviorComponent",
+        ),
     ],
 )
 def test_context_diagrams(


### PR DESCRIPTION
Finally include `PhysicalComponent` context diagrams into test cases.