### PR TITLE
feat: Add hierarchy recognition and handling to diagrams with ports

### DIFF
--- a/capellambse_context_diagrams/_elkjs.py
+++ b/capellambse_context_diagrams/_elkjs.py
@@ -68,13 +68,11 @@ LABEL_LAYOUT_OPTIONS = {"nodeLabels.placement": "OUTSIDE, V_BOTTOM, H_CENTER"}
 """Options for labels to configure ELK layouting."""
 
 
-class ELKInputData(te.TypedDict):
+class ELKInputData(te.TypedDict, total=False):
     """Data that can be fed to ELK."""
 
-    id: str
-    layoutOptions: te.NotRequired[
-        cabc.MutableMapping[str, t.Union[str, int, float]]
-    ]
+    id: te.Required[str]
+    layoutOptions: cabc.MutableMapping[str, t.Union[str, int, float]]
     children: cabc.MutableSequence[ELKInputChild]  # type: ignore
     edges: cabc.MutableSequence[ELKInputEdge]
 
@@ -82,7 +80,7 @@ class ELKInputData(te.TypedDict):
 class ELKInputChild(ELKInputData, total=False):
     """Children of either `ELKInputData` or `ELKInputChild`."""
 
-    labels: te.NotRequired[cabc.MutableSequence[ELKInputLabel]]
+    labels: cabc.MutableSequence[ELKInputLabel]
     ports: cabc.MutableSequence[ELKInputPort]
 
     width: t.Union[int, float]
@@ -105,7 +103,7 @@ class ELKInputPort(t.TypedDict):
     width: t.Union[int, float]
     height: t.Union[int, float]
 
-    layoutOptions: cabc.MutableMapping[str, t.Any]
+    layoutOptions: te.NotRequired[cabc.MutableMapping[str, t.Any]]
 
 
 class ELKInputEdge(te.TypedDict):

--- a/capellambse_context_diagrams/_elkjs.py
+++ b/capellambse_context_diagrams/_elkjs.py
@@ -72,18 +72,15 @@ class ELKInputData(te.TypedDict):
     """Data that can be fed to ELK."""
 
     id: str
-    layoutOptions: cabc.MutableMapping[str, t.Union[str, int, float]]
+    layoutOptions: te.NotRequired[
+        cabc.MutableMapping[str, t.Union[str, int, float]]
+    ]
     children: cabc.MutableSequence[ELKInputChild]  # type: ignore
     edges: cabc.MutableSequence[ELKInputEdge]
 
 
-class ELKInputChild(te.TypedDict, total=False):
+class ELKInputChild(ELKInputData, total=False):
     """Children of either `ELKInputData` or `ELKInputChild`."""
-
-    id: te.Required[str]
-    layoutOptions: cabc.MutableMapping[str, t.Union[str, int, float]]
-    children: cabc.MutableSequence[ELKInputChild]  # type: ignore
-    edges: cabc.MutableSequence[ELKInputEdge]
 
     labels: te.NotRequired[cabc.MutableSequence[ELKInputLabel]]
     ports: cabc.MutableSequence[ELKInputPort]

--- a/capellambse_context_diagrams/collectors/exchanges.py
+++ b/capellambse_context_diagrams/collectors/exchanges.py
@@ -299,3 +299,18 @@ class FunctionalContextCollector(ExchangeCollector):
             )
 
         return self.data["edges"]
+
+
+def is_hierarchical(
+    ex: common.GenericElement,
+    box: _elkjs.ELKInputChild,
+    key: t.Literal["ports"] | t.Literal["children"] = "ports",
+) -> bool:
+    """Check if the exchange is hierarchical (nested) inside ``box``."""
+    src, trg = generic.collect_exchange_endpoints(ex)
+    objs = {o["id"] for o in box[key]}
+    attr_map = {"children": "parent.uuid", "ports": "parent.parent.uuid"}
+    attr_getter = operator.attrgetter(attr_map[key])
+    source_contained = src.uuid in objs or attr_getter(src) == box["id"]
+    target_contained = trg.uuid in objs or attr_getter(trg) == box["id"]
+    return source_contained and target_contained

--- a/capellambse_context_diagrams/collectors/generic.py
+++ b/capellambse_context_diagrams/collectors/generic.py
@@ -126,7 +126,7 @@ def exchange_data_collector(
                 name,
             )
 
-    data.elkdata["edges"].append(
+    data.elkdata.setdefault("edges", []).append(
         {
             "id": render_adj.get("id", data.exchange.uuid),
             "sources": [render_adj.get("sources", source.uuid)],

--- a/capellambse_context_diagrams/serializers.py
+++ b/capellambse_context_diagrams/serializers.py
@@ -222,7 +222,10 @@ class DiagramSerializer:
         return styleoverrides
 
     def order_children(self) -> None:
-        new_diagram = diagram.Diagram(self.diagram.name, styleclass=self.diagram.styleclass) 
+        """Reorder diagram elements such that symbols are drawn last."""
+        new_diagram = diagram.Diagram(
+            self.diagram.name, styleclass=self.diagram.styleclass
+        )
         draw_last = list[diagram.DiagramElement]()
         for element in self.diagram:
             if element.JSON_TYPE in {"symbol", "circle"}:

--- a/capellambse_context_diagrams/serializers.py
+++ b/capellambse_context_diagrams/serializers.py
@@ -70,6 +70,7 @@ class DiagramSerializer:
             self.deserialize_child(child, diagram.Vector2D(), None)
 
         self.diagram.calculate_viewport()
+        self.order_children()
         return self.diagram
 
     def deserialize_child(
@@ -219,3 +220,17 @@ class DiagramSerializer:
 
             styleoverrides = style_condition(obj)
         return styleoverrides
+
+    def order_children(self) -> None:
+        new_diagram = diagram.Diagram(self.diagram.name, styleclass=self.diagram.styleclass) 
+        draw_last = list[diagram.DiagramElement]()
+        for element in self.diagram:
+            if element.JSON_TYPE in {"symbol", "circle"}:
+                draw_last.append(element)
+            else:
+                new_diagram.add_element(element)
+
+        for element in draw_last:
+            new_diagram.add_element(element)
+
+        self.diagram = new_diagram

--- a/docs/gen_images.py
+++ b/docs/gen_images.py
@@ -26,6 +26,7 @@ general_context_diagram_uuids = {
     "educate Wizards": "957c5799-1d4a-4ac0-b5de-33a65bf1519c",
     "Weird guy": "098810d9-0325-4ae8-a111-82202c0d2016",
     "Top secret": "5bf3f1e3-0f5e-4fec-81d5-c113d3a1b3a6",
+    "Hierarchy": "16b4fcc5-548d-4721-b62a-d3d5b1c1d2eb",
 }
 interface_context_diagram_uuids = {
     "Left to right": "3ef23099-ce9a-4f7d-812f-935f47e7938d",

--- a/docs/index.md
+++ b/docs/index.md
@@ -153,6 +153,19 @@ Available via `.context_diagram` on a [`ModelObject`][capellambse.model.common.e
 * [`pa.PhysicalComponent`][capellambse.model.layers.pa.PhysicalComponent] (PAB)
 * [`pa.PhysicalFunction`][capellambse.model.layers.pa.PhysicalFunction] (PDFB)
 
+#### Hierarchy in diagrams
+
+Hierarchical diagrams are diagrams where boxes have child boxes and edges
+contained. These form subdiagrams which can be layouted via ELK again.
+Hierarchy is identified and supported:
+
+??? example "Hierarchical diagram"
+
+        <figure markdown>
+            <img src="assets/images/Context of Hierarchy.svg" width="1000000">
+            <figcaption>Context diagram of Hierarchy LogicalComponenet with type [LAB]</figcaption>
+        </figure>
+
 ### Interfaces (aka ComponentExchanges)
 
 The data is collected by [get_elkdata_for_exchanges][capellambse_context_diagrams.collectors.exchanges.get_elkdata_for_exchanges] which is using the [`InterfaceContextCollector`][capellambse_context_diagrams.collectors.exchanges.InterfaceContextCollector] underneath.

--- a/tests/data/ContextDiagram.aird
+++ b/tests/data/ContextDiagram.aird
@@ -74,6 +74,14 @@
         <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']"/>
         <target xmi:type="org.polarsys.capella.core.data.la:LogicalComponentPkg" href="ContextDiagram.capella#84c0978d-9a32-4f5b-8013-5b0b6adbfd73"/>
       </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_fc_gAM4PEe2lc9VKdL15dA" name="[LAB] Hierarchy" repPath="#_fco6sM4PEe2lc9VKdL15dA" changeId="f2f313b6-9a4f-4ac2-9c7c-c6f87658308d">
+        <eAnnotations xmi:type="description:DAnnotation" uid="_fdYhkM4PEe2lc9VKdL15dA" source="https://www.polarsys.org/capella/dannotation/DesactivatedFilters">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_fdZIoM4PEe2lc9VKdL15dA" key="hide.computed.component.exchanges.filter" value="true"/>
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_fdZIoc4PEe2lc9VKdL15dA" key="hide.computed.physical.links.filter" value="true"/>
+        </eAnnotations>
+        <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']"/>
+        <target xmi:type="org.polarsys.capella.core.data.la:LogicalComponentPkg" href="ContextDiagram.capella#84c0978d-9a32-4f5b-8013-5b0b6adbfd73"/>
+      </ownedRepresentationDescriptors>
     </ownedViews>
     <ownedViews xmi:type="viewpoint:DView" uid="_4Dt18PHWEeq9N-vcO9FSUw">
       <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.kitalpha.vp.requirements.design/description/Requirements.odesign#//@ownedViewpoints[name='Requirements_ID']"/>
@@ -7446,5 +7454,528 @@
     <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/context.odesign#//@ownedViewpoints[name='System%20Analysis']/@ownedRepresentations[name='Missions%20Capabilities%20Blank']/@defaultLayer"/>
     <activatedLayers xmi:type="description_1:AdditionalLayer" href="platform:/plugin/org.polarsys.capella.vp.requirements.design/description/CapellaRequirements.odesign#//@ownedViewpoints[name='CapellaRequirements_ID']/@ownedRepresentationExtensions[name='CapellaViewpoints']/@layers[name='ReqVP_Requirements_Layer']"/>
     <target xmi:type="org.polarsys.capella.core.data.ctx:CapabilityPkg" href="ContextDiagram.capella#1fded3ea-675d-4b0d-b018-3502a77a5b67"/>
+  </diagram:DSemanticDiagram>
+  <diagram:DSemanticDiagram uid="_fco6sM4PEe2lc9VKdL15dA">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_fdOJgM4PEe2lc9VKdL15dA" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_fdOJgc4PEe2lc9VKdL15dA" type="Sirius" element="_fco6sM4PEe2lc9VKdL15dA" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_hJ8xEM4PEe2lc9VKdL15dA" type="2002" element="_hJVGAM4PEe2lc9VKdL15dA">
+          <children xmi:type="notation:Node" xmi:id="_hJ9_MM4PEe2lc9VKdL15dA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_hJ-mQM4PEe2lc9VKdL15dA" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_mENroM4PEe2lc9VKdL15dA" type="3008" element="_mDn1wM4PEe2lc9VKdL15dA">
+              <children xmi:type="notation:Node" xmi:id="_mENro84PEe2lc9VKdL15dA" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_mEOSsM4PEe2lc9VKdL15dA" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_mEOSsc4PEe2lc9VKdL15dA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_mEOSss4PEe2lc9VKdL15dA"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_QSFmoM4QEe2lc9VKdL15dA" type="3012" element="_QRi0EM4QEe2lc9VKdL15dA">
+                <children xmi:type="notation:Node" xmi:id="_QSGNsM4QEe2lc9VKdL15dA" visible="false" type="5010">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_QSGNsc4QEe2lc9VKdL15dA" y="11"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_q10kAM4QEe2lc9VKdL15dA" type="3005" element="_q1JOls4QEe2lc9VKdL15dA">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_q10kAc4QEe2lc9VKdL15dA" fontName="Fira Code"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_q10kAs4QEe2lc9VKdL15dA"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_QSFmoc4QEe2lc9VKdL15dA" fontName="Fira Code" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QSFmos4QEe2lc9VKdL15dA" x="-2" y="30" width="10" height="10"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_mENroc4PEe2lc9VKdL15dA" fontName="Fira Code" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mENros4PEe2lc9VKdL15dA" x="85" y="65"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_FfLdsM4QEe2lc9VKdL15dA" type="3008" element="_Fe4iwM4QEe2lc9VKdL15dA">
+              <children xmi:type="notation:Node" xmi:id="_FfLds84QEe2lc9VKdL15dA" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_FfLdtM4QEe2lc9VKdL15dA" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_FfLdtc4QEe2lc9VKdL15dA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_FfLdts4QEe2lc9VKdL15dA"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_eY8zoM4QEe2lc9VKdL15dA" type="3012" element="_eX8uEM4QEe2lc9VKdL15dA">
+                <children xmi:type="notation:Node" xmi:id="_eY9asM4QEe2lc9VKdL15dA" visible="false" type="5010">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_eY9asc4QEe2lc9VKdL15dA" x="11"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_pqk44M4QEe2lc9VKdL15dA" type="3005" element="_pp6Khc4QEe2lc9VKdL15dA">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_pqk44c4QEe2lc9VKdL15dA" fontName="Fira Code"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pqk44s4QEe2lc9VKdL15dA"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_eY8zoc4QEe2lc9VKdL15dA" fontName="Fira Code" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eY8zos4QEe2lc9VKdL15dA" x="140" y="30" width="10" height="10"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_FfLdsc4QEe2lc9VKdL15dA" fontName="Fira Code" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FfLdss4QEe2lc9VKdL15dA" x="85" y="204"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_hJ-mQc4PEe2lc9VKdL15dA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_hJ-mQs4PEe2lc9VKdL15dA"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_KM4i8M4QEe2lc9VKdL15dA" type="3012" element="_KMEDkM4QEe2lc9VKdL15dA">
+            <children xmi:type="notation:Node" xmi:id="_KM5KAM4QEe2lc9VKdL15dA" visible="false" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_KM5KAc4QEe2lc9VKdL15dA" y="11"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_KNAewM4QEe2lc9VKdL15dA" type="3005" element="_KMEqoM4QEe2lc9VKdL15dA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_KNAewc4QEe2lc9VKdL15dA" fontName="Fira Code"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KNAews4QEe2lc9VKdL15dA"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_KM4i8c4QEe2lc9VKdL15dA" fontName="Fira Code" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KM4i8s4QEe2lc9VKdL15dA" x="-2" y="100" width="10" height="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_LIM7sM4QEe2lc9VKdL15dA" type="3012" element="_LHfKAM4QEe2lc9VKdL15dA">
+            <children xmi:type="notation:Node" xmi:id="_LIM7s84QEe2lc9VKdL15dA" visible="false" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_LIM7tM4QEe2lc9VKdL15dA" y="11"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_LIM7tc4QEe2lc9VKdL15dA" type="3005" element="_LHfKAc4QEe2lc9VKdL15dA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_LIM7ts4QEe2lc9VKdL15dA" fontName="Fira Code"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LIM7t84QEe2lc9VKdL15dA"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_LIM7sc4QEe2lc9VKdL15dA" fontName="Fira Code" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LIM7ss4QEe2lc9VKdL15dA" x="-2" y="200" width="10" height="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_Lo3YwM4QEe2lc9VKdL15dA" type="3012" element="_LoYQkM4QEe2lc9VKdL15dA">
+            <children xmi:type="notation:Node" xmi:id="_Lo3Yw84QEe2lc9VKdL15dA" visible="false" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_Lo3YxM4QEe2lc9VKdL15dA" y="11"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_Lo3Yxc4QEe2lc9VKdL15dA" type="3005" element="_LoY3oM4QEe2lc9VKdL15dA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_Lo3Yxs4QEe2lc9VKdL15dA" fontName="Fira Code"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Lo3Yx84QEe2lc9VKdL15dA"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_Lo3Ywc4QEe2lc9VKdL15dA" fontName="Fira Code" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Lo3Yws4QEe2lc9VKdL15dA" x="323" y="89" width="10" height="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_MIIHoM4QEe2lc9VKdL15dA" type="3012" element="_MHX5sM4QEe2lc9VKdL15dA">
+            <children xmi:type="notation:Node" xmi:id="_MIIusM4QEe2lc9VKdL15dA" visible="false" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_MIIusc4QEe2lc9VKdL15dA" y="11"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_MIIuss4QEe2lc9VKdL15dA" type="3005" element="_MHX5sc4QEe2lc9VKdL15dA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_MIIus84QEe2lc9VKdL15dA" fontName="Fira Code"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MIIutM4QEe2lc9VKdL15dA"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_MIIHoc4QEe2lc9VKdL15dA" fontName="Fira Code" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MIIHos4QEe2lc9VKdL15dA" x="323" y="239" width="10" height="10"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_hJ8xEc4PEe2lc9VKdL15dA" fontName="Fira Code" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hJ8xEs4PEe2lc9VKdL15dA" x="600" y="200" width="333" height="343"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_i7-vYM4PEe2lc9VKdL15dA" type="2002" element="_i7WdQM4PEe2lc9VKdL15dA">
+          <children xmi:type="notation:Node" xmi:id="_i7-vY84PEe2lc9VKdL15dA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_i7-vZM4PEe2lc9VKdL15dA" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_i7-vZc4PEe2lc9VKdL15dA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_i7-vZs4PEe2lc9VKdL15dA"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_KNBF0M4QEe2lc9VKdL15dA" type="3012" element="_KL_LEM4QEe2lc9VKdL15dA">
+            <children xmi:type="notation:Node" xmi:id="_KNBF084QEe2lc9VKdL15dA" visible="false" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_KNBF1M4QEe2lc9VKdL15dA" x="11"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_KNEJIM4QEe2lc9VKdL15dA" type="3005" element="_KMCOYM4QEe2lc9VKdL15dA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_KNEJIc4QEe2lc9VKdL15dA" fontName="Fira Code"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KNEJIs4QEe2lc9VKdL15dA"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_KNBF0c4QEe2lc9VKdL15dA" fontName="Fira Code" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KNBF0s4QEe2lc9VKdL15dA" x="140" y="30" width="10" height="10"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_i7-vYc4PEe2lc9VKdL15dA" fontName="Fira Code" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_i7-vYs4PEe2lc9VKdL15dA" x="200" y="270"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_kqyakM4PEe2lc9VKdL15dA" type="2002" element="_kqUggM4PEe2lc9VKdL15dA">
+          <children xmi:type="notation:Node" xmi:id="_kqzBoM4PEe2lc9VKdL15dA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_kqzBoc4PEe2lc9VKdL15dA" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_kqzBos4PEe2lc9VKdL15dA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_kqzBo84PEe2lc9VKdL15dA"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_LINiwM4QEe2lc9VKdL15dA" type="3012" element="_LHd74M4QEe2lc9VKdL15dA">
+            <children xmi:type="notation:Node" xmi:id="_LINiw84QEe2lc9VKdL15dA" visible="false" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_LINixM4QEe2lc9VKdL15dA" x="11"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_LIOJ0M4QEe2lc9VKdL15dA" type="3005" element="_LHei8M4QEe2lc9VKdL15dA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_LIOJ0c4QEe2lc9VKdL15dA" fontName="Fira Code"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LIOJ0s4QEe2lc9VKdL15dA"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_LINiwc4QEe2lc9VKdL15dA" fontName="Fira Code" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LINiws4QEe2lc9VKdL15dA" x="140" y="30" width="10" height="10"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_kqyakc4PEe2lc9VKdL15dA" fontName="Fira Code" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kqyaks4PEe2lc9VKdL15dA" x="200" y="370"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_nekw0M4PEe2lc9VKdL15dA" type="2002" element="_neNkcM4PEe2lc9VKdL15dA">
+          <children xmi:type="notation:Node" xmi:id="_nekw084PEe2lc9VKdL15dA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_nekw1M4PEe2lc9VKdL15dA" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_nekw1c4PEe2lc9VKdL15dA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_nekw1s4PEe2lc9VKdL15dA"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_Lo3_0M4QEe2lc9VKdL15dA" type="3012" element="_LoaFwM4QEe2lc9VKdL15dA">
+            <children xmi:type="notation:Node" xmi:id="_Lo3_084QEe2lc9VKdL15dA" visible="false" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_Lo3_1M4QEe2lc9VKdL15dA" y="11"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_Lo3_1c4QEe2lc9VKdL15dA" type="3005" element="_LoaFwc4QEe2lc9VKdL15dA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_Lo3_1s4QEe2lc9VKdL15dA" fontName="Fira Code"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Lo3_184QEe2lc9VKdL15dA"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_Lo3_0c4QEe2lc9VKdL15dA" fontName="Fira Code" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Lo3_0s4QEe2lc9VKdL15dA" x="-2" y="30" width="10" height="10"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_nekw0c4PEe2lc9VKdL15dA" fontName="Fira Code" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nekw0s4PEe2lc9VKdL15dA" x="1150" y="260"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_osJ-QM4PEe2lc9VKdL15dA" type="2002" element="_orxjwM4PEe2lc9VKdL15dA">
+          <children xmi:type="notation:Node" xmi:id="_osKlUM4PEe2lc9VKdL15dA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_osKlUc4PEe2lc9VKdL15dA" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_osKlUs4PEe2lc9VKdL15dA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_osKlU84PEe2lc9VKdL15dA"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_MIJVwM4QEe2lc9VKdL15dA" type="3012" element="_MHZH0M4QEe2lc9VKdL15dA">
+            <children xmi:type="notation:Node" xmi:id="_MIJVw84QEe2lc9VKdL15dA" visible="false" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_MIJVxM4QEe2lc9VKdL15dA" y="11"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_MIJVxc4QEe2lc9VKdL15dA" type="3005" element="_MHZH0c4QEe2lc9VKdL15dA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_MIJVxs4QEe2lc9VKdL15dA" fontName="Fira Code"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MIJVx84QEe2lc9VKdL15dA"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_MIJVwc4QEe2lc9VKdL15dA" fontName="Fira Code" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MIJVws4QEe2lc9VKdL15dA" x="-2" y="30" width="10" height="10"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_osJ-Qc4PEe2lc9VKdL15dA" fontName="Fira Code" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_osJ-Qs4PEe2lc9VKdL15dA" x="1150" y="410"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_fdOJgs4PEe2lc9VKdL15dA"/>
+        <edges xmi:type="notation:Edge" xmi:id="_KNFXQM4QEe2lc9VKdL15dA" type="4001" element="_KMI8EM4QEe2lc9VKdL15dA" source="_KNBF0M4QEe2lc9VKdL15dA" target="_KM4i8M4QEe2lc9VKdL15dA">
+          <children xmi:type="notation:Node" xmi:id="_KNF-UM4QEe2lc9VKdL15dA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KNF-Uc4QEe2lc9VKdL15dA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_KNGlYM4QEe2lc9VKdL15dA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KNGlYc4QEe2lc9VKdL15dA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_KNGlYs4QEe2lc9VKdL15dA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KNGlY84QEe2lc9VKdL15dA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_KNFXQc4QEe2lc9VKdL15dA" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_KNFXQs4QEe2lc9VKdL15dA" fontColor="9914954" fontName="Fira Code" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_KNFXQ84QEe2lc9VKdL15dA" points="[5, 0, -253, 0]$[253, 0, -5, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KNIakM4QEe2lc9VKdL15dA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KNIakc4QEe2lc9VKdL15dA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_LIOJ084QEe2lc9VKdL15dA" type="4001" element="_LHgYIM4QEe2lc9VKdL15dA" source="_LINiwM4QEe2lc9VKdL15dA" target="_LIM7sM4QEe2lc9VKdL15dA">
+          <children xmi:type="notation:Node" xmi:id="_LIOJ184QEe2lc9VKdL15dA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LIOJ2M4QEe2lc9VKdL15dA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_LIOJ2c4QEe2lc9VKdL15dA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LIOJ2s4QEe2lc9VKdL15dA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_LIOJ284QEe2lc9VKdL15dA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LIOJ3M4QEe2lc9VKdL15dA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_LIOJ1M4QEe2lc9VKdL15dA" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_LIOJ1c4QEe2lc9VKdL15dA" fontColor="9914954" fontName="Fira Code" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_LIOJ1s4QEe2lc9VKdL15dA" points="[5, 0, -253, 0]$[253, 0, -5, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LIOw4M4QEe2lc9VKdL15dA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LIOw4c4QEe2lc9VKdL15dA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_Lo4m4M4QEe2lc9VKdL15dA" type="4001" element="_Loas0M4QEe2lc9VKdL15dA" source="_Lo3YwM4QEe2lc9VKdL15dA" target="_Lo3_0M4QEe2lc9VKdL15dA">
+          <children xmi:type="notation:Node" xmi:id="_Lo4m5M4QEe2lc9VKdL15dA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Lo4m5c4QEe2lc9VKdL15dA" x="-2" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_Lo4m5s4QEe2lc9VKdL15dA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Lo4m584QEe2lc9VKdL15dA" x="-3" y="9"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_Lo4m6M4QEe2lc9VKdL15dA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Lo4m6c4QEe2lc9VKdL15dA" y="8"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_Lo4m4c4QEe2lc9VKdL15dA" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_Lo4m4s4QEe2lc9VKdL15dA" fontColor="9914954" fontName="Fira Code" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Lo4m484QEe2lc9VKdL15dA" points="[5, 0, -220, -1]$[220, 0, -5, -1]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Lo4m6s4QEe2lc9VKdL15dA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Lo4m684QEe2lc9VKdL15dA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_MIJ80M4QEe2lc9VKdL15dA" type="4001" element="_MHaV8M4QEe2lc9VKdL15dA" source="_MIIHoM4QEe2lc9VKdL15dA" target="_MIJVwM4QEe2lc9VKdL15dA">
+          <children xmi:type="notation:Node" xmi:id="_MIJ81M4QEe2lc9VKdL15dA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MIJ81c4QEe2lc9VKdL15dA" x="-1" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_MIJ81s4QEe2lc9VKdL15dA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MIJ8184QEe2lc9VKdL15dA" x="-2" y="9"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_MIJ82M4QEe2lc9VKdL15dA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MIJ82c4QEe2lc9VKdL15dA" x="-1" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_MIJ80c4QEe2lc9VKdL15dA" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_MIJ80s4QEe2lc9VKdL15dA" fontColor="9914954" fontName="Fira Code" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MIJ8084QEe2lc9VKdL15dA" points="[5, 0, -220, -1]$[220, 0, -5, -1]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MIJ82s4QEe2lc9VKdL15dA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MIJ8284QEe2lc9VKdL15dA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_QSG0w84QEe2lc9VKdL15dA" type="4001" element="_QRkCMM4QEe2lc9VKdL15dA" source="_QSFmoM4QEe2lc9VKdL15dA" target="_KM4i8M4QEe2lc9VKdL15dA">
+          <children xmi:type="notation:Node" xmi:id="_QSHb0M4QEe2lc9VKdL15dA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QSHb0c4QEe2lc9VKdL15dA" x="2" y="-7"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_QSHb0s4QEe2lc9VKdL15dA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QSHb084QEe2lc9VKdL15dA" x="-1" y="11"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_QSHb1M4QEe2lc9VKdL15dA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QSHb1c4QEe2lc9VKdL15dA" x="-1" y="9"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_QSG0xM4QEe2lc9VKdL15dA" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_QSG0xc4QEe2lc9VKdL15dA" fontColor="9914954" fontName="Fira Code" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QSG0xs4QEe2lc9VKdL15dA" points="[0, 0, 80, 1]$[-80, -1, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QSHb1s4QEe2lc9VKdL15dA" id="(0.0,0.4411764705882353)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QSHb184QEe2lc9VKdL15dA" id="(1.0,0.4)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_eY-BwM4QEe2lc9VKdL15dA" type="4001" element="_eX9VIs4QEe2lc9VKdL15dA" source="_MIIHoM4QEe2lc9VKdL15dA" target="_eY8zoM4QEe2lc9VKdL15dA">
+          <children xmi:type="notation:Node" xmi:id="_eY-BxM4QEe2lc9VKdL15dA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eY-Bxc4QEe2lc9VKdL15dA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_eY-Bxs4QEe2lc9VKdL15dA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eY-Bx84QEe2lc9VKdL15dA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_eY-ByM4QEe2lc9VKdL15dA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eY-Byc4QEe2lc9VKdL15dA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_eY-Bwc4QEe2lc9VKdL15dA" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_eY-Bws4QEe2lc9VKdL15dA" fontColor="9914954" fontName="Fira Code" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eY-Bw84QEe2lc9VKdL15dA" points="[0, 0, 85, 0]$[-85, 0, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eY-Bys4QEe2lc9VKdL15dA" id="(0.0,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eY-By84QEe2lc9VKdL15dA" id="(1.0,0.5)"/>
+        </edges>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_fe-dAM4PEe2lc9VKdL15dA" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_fe-dAc4PEe2lc9VKdL15dA"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_hJVGAM4PEe2lc9VKdL15dA" name="Middle">
+      <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#92df1186-3cde-4e9e-9d6b-6609d006f36d"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#92df1186-3cde-4e9e-9d6b-6609d006f36d"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalComponent" href="ContextDiagram.capella#16b4fcc5-548d-4721-b62a-d3d5b1c1d2eb"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_KMEDkM4QEe2lc9VKdL15dA" name="CP 3" incomingEdges="_KMI8EM4QEe2lc9VKdL15dA _QRkCMM4QEe2lc9VKdL15dA" width="1" height="1">
+        <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#4f111d67-92a8-4a39-845e-a0662401c889"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#4f111d67-92a8-4a39-845e-a0662401c889"/>
+        <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_KMEqos4QEe2lc9VKdL15dA"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_KMEqoM4QEe2lc9VKdL15dA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/InFlowPort.png">
+          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.1/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
+      </ownedBorderedNodes>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_LHfKAM4QEe2lc9VKdL15dA" name="CP 4" incomingEdges="_LHgYIM4QEe2lc9VKdL15dA" width="1" height="1">
+        <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#0b558f0b-dd4a-4f35-ad88-f4abe44df415"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#0b558f0b-dd4a-4f35-ad88-f4abe44df415"/>
+        <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_LHfxEc4QEe2lc9VKdL15dA"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_LHfKAc4QEe2lc9VKdL15dA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/InFlowPort.png">
+          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.1/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
+      </ownedBorderedNodes>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_LoYQkM4QEe2lc9VKdL15dA" name="CP 5" outgoingEdges="_Loas0M4QEe2lc9VKdL15dA" width="1" height="1">
+        <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#5442bfe8-79d8-45b5-bf49-29f7f0c6f635"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#5442bfe8-79d8-45b5-bf49-29f7f0c6f635"/>
+        <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_LoY3os4QEe2lc9VKdL15dA"/>
+        <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+        <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+        <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_LoY3oM4QEe2lc9VKdL15dA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/OutFlowPort.png">
+          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.2/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
+      </ownedBorderedNodes>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_MHX5sM4QEe2lc9VKdL15dA" name="CP 6" outgoingEdges="_MHaV8M4QEe2lc9VKdL15dA _eX9VIs4QEe2lc9VKdL15dA" width="1" height="1">
+        <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#126c2f86-0fd5-4bc7-bdde-db32aadbd69c"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#126c2f86-0fd5-4bc7-bdde-db32aadbd69c"/>
+        <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_MHYgwc4QEe2lc9VKdL15dA"/>
+        <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+        <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+        <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_MHX5sc4QEe2lc9VKdL15dA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/OutFlowPort.png">
+          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.2/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
+      </ownedBorderedNodes>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_hJYwYM4PEe2lc9VKdL15dA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="195,230,255" foregroundColor="150,177,218">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_mDn1wM4PEe2lc9VKdL15dA" name="Inner 1">
+        <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#9344f33d-d8e1-45f2-9fd9-4686d4a6cf83"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#9344f33d-d8e1-45f2-9fd9-4686d4a6cf83"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalComponent" href="ContextDiagram.capella#31bc2326-5a55-45f9-9967-f1957bcd3f89"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_QRi0EM4QEe2lc9VKdL15dA" name="CP 1" outgoingEdges="_QRkCMM4QEe2lc9VKdL15dA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#5d162922-7b14-4671-81ed-8fd2a240ae13"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#5d162922-7b14-4671-81ed-8fd2a240ae13"/>
+          <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_QRjbIs4QEe2lc9VKdL15dA"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_q1JOls4QEe2lc9VKdL15dA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/InFlowPort.png">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.1/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
+        </ownedBorderedNodes>
+        <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+        <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+        <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_mDoc0M4PEe2lc9VKdL15dA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="195,230,255" foregroundColor="150,177,218">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']"/>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_Fe4iwM4QEe2lc9VKdL15dA" name="Inner 2">
+        <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#68f12996-2024-4046-b6ac-76ce9c558ef4"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#68f12996-2024-4046-b6ac-76ce9c558ef4"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalComponent" href="ContextDiagram.capella#ad0bdf2f-bd0e-48bc-9296-5be3371a76e2"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_eX8uEM4QEe2lc9VKdL15dA" name="CP 1" incomingEdges="_eX9VIs4QEe2lc9VKdL15dA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#087cbba9-bc3c-4cfc-a004-0a6d2ea24696"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#087cbba9-bc3c-4cfc-a004-0a6d2ea24696"/>
+          <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_eX9VIc4QEe2lc9VKdL15dA"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_pp6Khc4QEe2lc9VKdL15dA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/OutFlowPort.png">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.2/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
+        </ownedBorderedNodes>
+        <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+        <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+        <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_Fe4iwc4QEe2lc9VKdL15dA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="195,230,255" foregroundColor="150,177,218">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']"/>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_i7WdQM4PEe2lc9VKdL15dA" name="Left 1">
+      <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#8186a7ec-045a-433a-bece-672b767775fe"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#8186a7ec-045a-433a-bece-672b767775fe"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalComponent" href="ContextDiagram.capella#1c416771-64bc-4d0c-99eb-296ce27d0a35"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_KL_LEM4QEe2lc9VKdL15dA" name="CP 1" outgoingEdges="_KMI8EM4QEe2lc9VKdL15dA" width="1" height="1">
+        <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#9fe7caff-fe85-46ea-8214-9820328aac73"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#9fe7caff-fe85-46ea-8214-9820328aac73"/>
+        <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_KMDcgM4QEe2lc9VKdL15dA"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_KMCOYM4QEe2lc9VKdL15dA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/OutFlowPort.png">
+          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.2/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_i7XEUM4PEe2lc9VKdL15dA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="195,230,255" foregroundColor="150,177,218">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_kqUggM4PEe2lc9VKdL15dA" name="Left 2">
+      <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#e5e3527b-ac6f-43a4-9ed4-ecb55d8b1bcd"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#e5e3527b-ac6f-43a4-9ed4-ecb55d8b1bcd"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalComponent" href="ContextDiagram.capella#57635b74-b251-4b9b-8cc3-706dcc7b65db"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_LHd74M4QEe2lc9VKdL15dA" name="CP 1" outgoingEdges="_LHgYIM4QEe2lc9VKdL15dA" width="1" height="1">
+        <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#3e0a3791-cc99-4af5-b789-5b33451ca743"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#3e0a3791-cc99-4af5-b789-5b33451ca743"/>
+        <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_LHei8s4QEe2lc9VKdL15dA"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_LHei8M4QEe2lc9VKdL15dA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/OutFlowPort.png">
+          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.2/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
+      </ownedBorderedNodes>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_kqVHkM4PEe2lc9VKdL15dA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="218,253,255" foregroundColor="198,230,255">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@conditionnalStyles.0/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_neNkcM4PEe2lc9VKdL15dA" name="Right 1">
+      <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#1a9e3f71-bf4d-442b-a3f3-9a97076f8390"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#1a9e3f71-bf4d-442b-a3f3-9a97076f8390"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalComponent" href="ContextDiagram.capella#c999f0f0-49d0-4b01-b260-f69dc63abbcb"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_LoaFwM4QEe2lc9VKdL15dA" name="CP 1" incomingEdges="_Loas0M4QEe2lc9VKdL15dA" width="1" height="1">
+        <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#5ccac19c-76d3-405d-8fc3-85c8958dab45"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#5ccac19c-76d3-405d-8fc3-85c8958dab45"/>
+        <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_LoaFw84QEe2lc9VKdL15dA"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_LoaFwc4QEe2lc9VKdL15dA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/InFlowPort.png">
+          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.1/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
+      </ownedBorderedNodes>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_neNkcc4PEe2lc9VKdL15dA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="195,230,255" foregroundColor="150,177,218">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_orxjwM4PEe2lc9VKdL15dA" name="Right 2">
+      <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#878e9589-a9f7-47b9-8fda-f009184716c5"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#878e9589-a9f7-47b9-8fda-f009184716c5"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalComponent" href="ContextDiagram.capella#ea3ff951-47ec-441e-aae6-c5103d47cf1a"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_MHZH0M4QEe2lc9VKdL15dA" name="CP 1" incomingEdges="_MHaV8M4QEe2lc9VKdL15dA" width="1" height="1">
+        <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#b557cfc6-ca9a-40f5-b6f7-14e61523bd9a"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#b557cfc6-ca9a-40f5-b6f7-14e61523bd9a"/>
+        <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_MHZu4c4QEe2lc9VKdL15dA"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_MHZH0c4QEe2lc9VKdL15dA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/InFlowPort.png">
+          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.1/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
+      </ownedBorderedNodes>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_oryK0M4PEe2lc9VKdL15dA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="195,230,255" foregroundColor="150,177,218">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_KMI8EM4QEe2lc9VKdL15dA" name="o1" sourceNode="_KL_LEM4QEe2lc9VKdL15dA" targetNode="_KMEDkM4QEe2lc9VKdL15dA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#031de9d3-13ee-405c-93f1-81a42a9b1bf3"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#031de9d3-13ee-405c-93f1-81a42a9b1bf3"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_KMKxQM4QEe2lc9VKdL15dA" targetArrow="NoDecoration" centered="Both" strokeColor="74,74,151">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']/@conditionnalStyles.3/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_KMKxQc4QEe2lc9VKdL15dA" labelColor="74,74,151"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_LHgYIM4QEe2lc9VKdL15dA" name="o2" sourceNode="_LHd74M4QEe2lc9VKdL15dA" targetNode="_LHfKAM4QEe2lc9VKdL15dA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#5286d854-84cc-4514-88ab-d0d67c6ddd37"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#5286d854-84cc-4514-88ab-d0d67c6ddd37"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_LHg_MM4QEe2lc9VKdL15dA" targetArrow="NoDecoration" centered="Both" strokeColor="74,74,151">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']/@conditionnalStyles.3/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_LHg_Mc4QEe2lc9VKdL15dA" labelColor="74,74,151"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_Loas0M4QEe2lc9VKdL15dA" name="o3" sourceNode="_LoYQkM4QEe2lc9VKdL15dA" targetNode="_LoaFwM4QEe2lc9VKdL15dA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#1c050208-ea5e-403e-8987-5090dbcb0a02"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#1c050208-ea5e-403e-8987-5090dbcb0a02"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_Loas0c4QEe2lc9VKdL15dA" targetArrow="NoDecoration" centered="Both" strokeColor="74,74,151">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']/@conditionnalStyles.3/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_Loas0s4QEe2lc9VKdL15dA" labelColor="74,74,151"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_MHaV8M4QEe2lc9VKdL15dA" name="o4" sourceNode="_MHX5sM4QEe2lc9VKdL15dA" targetNode="_MHZH0M4QEe2lc9VKdL15dA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#8805a65b-d220-416d-ac04-b614cf7a8456"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#8805a65b-d220-416d-ac04-b614cf7a8456"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_MHa9AM4QEe2lc9VKdL15dA" targetArrow="NoDecoration" centered="Both" strokeColor="74,74,151">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']/@conditionnalStyles.3/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_MHa9Ac4QEe2lc9VKdL15dA" labelColor="74,74,151"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_QRkCMM4QEe2lc9VKdL15dA" name="i1" sourceNode="_QRi0EM4QEe2lc9VKdL15dA" targetNode="_KMEDkM4QEe2lc9VKdL15dA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#4a8f4058-3ef1-4e76-8c0f-41d45ed8f669"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#4a8f4058-3ef1-4e76-8c0f-41d45ed8f669"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_QRkpQM4QEe2lc9VKdL15dA" targetArrow="NoDecoration" centered="Both" strokeColor="74,74,151">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']/@conditionnalStyles.3/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_QRkpQc4QEe2lc9VKdL15dA" labelColor="74,74,151"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_eX9VIs4QEe2lc9VKdL15dA" name="i2" sourceNode="_MHX5sM4QEe2lc9VKdL15dA" targetNode="_eX8uEM4QEe2lc9VKdL15dA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#1b23d65b-44d4-4d19-808e-8eae5756dd90"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#1b23d65b-44d4-4d19-808e-8eae5756dd90"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_eX98MM4QEe2lc9VKdL15dA" targetArrow="NoDecoration" centered="Both" strokeColor="74,74,151">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']/@conditionnalStyles.3/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_eX98Mc4QEe2lc9VKdL15dA" labelColor="74,74,151"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']"/>
+    <currentConcern xmi:type="concern:ConcernDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@concerns/@ownedConcernDescriptions.0"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@filters[name='hide.overlappedphysical.paths.label.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@filters[name='hide.simplified.diagram.based.component.exchanges.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@filters[name='hide.overlappedfunctional.chains.label.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@filters[name='hide.simplified.group.of.component.exchanges.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@filters[name='hide.simplified.oriented.grouped.component.exchanges.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@filters[name='hide.sequencing.information.filter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_fctMIM4PEe2lc9VKdL15dA"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer"/>
+    <activatedLayers xmi:type="description_1:AdditionalLayer" href="platform:/plugin/org.polarsys.capella.vp.requirements.design/description/CapellaRequirements.odesign#//@ownedViewpoints[name='CapellaRequirements_ID']/@ownedRepresentationExtensions[name='CapellaViewpoints']/@layers[name='ReqVP_Requirements_Layer']"/>
+    <target xmi:type="org.polarsys.capella.core.data.la:LogicalComponentPkg" href="ContextDiagram.capella#84c0978d-9a32-4f5b-8013-5b0b6adbfd73"/>
   </diagram:DSemanticDiagram>
 </xmi:XMI>

--- a/tests/data/ContextDiagram.capella
+++ b/tests/data/ContextDiagram.capella
@@ -2891,6 +2891,8 @@ The predator is far away</bodies>
             name="LogicalActor 5" abstractType="#3e0ee19f-0e3f-49d4-ae99-29bd4a3260c5"/>
         <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="f06eeca4-0e17-45c4-9b9d-244896e32720"
             name="Multiport" abstractType="#b3888dad-a870-4b8b-97d4-0ddb83ef9251"/>
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="e5e3527b-ac6f-43a4-9ed4-ecb55d8b1bcd"
+            name="Left 2" abstractType="#57635b74-b251-4b9b-8cc3-706dcc7b65db"/>
         <ownedComponentExchanges xsi:type="org.polarsys.capella.core.data.fa:ComponentExchange"
             id="c0bc49e1-8043-4418-8c0a-de6c6b749eab" name="Headmaster Responsibilities"
             convoyedInformations="#408f9055-bdcf-4181-865c-db3e823bd93d" source="#fcbf6881-720c-421f-9fe9-12fc3dfefe9c"
@@ -2930,6 +2932,9 @@ The predator is far away</bodies>
               id="ba555a31-5910-4daf-9e64-90e413a038e7" targetElement="#24e69680-5e36-44c6-8d9c-28d18a37d44d"
               sourceElement="#bf1a8b47-d60e-4df3-80bf-c6d5bfc84901"/>
         </ownedComponentExchanges>
+        <ownedComponentExchanges xsi:type="org.polarsys.capella.core.data.fa:ComponentExchange"
+            id="5286d854-84cc-4514-88ab-d0d67c6ddd37" name="o2" source="#3e0a3791-cc99-4af5-b789-5b33451ca743"
+            target="#0b558f0b-dd4a-4f35-ad88-f4abe44df415" kind="FLOW"/>
         <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
             id="0d2edb8f-fa34-4e73-89ec-fb9a63001440" name="Hogwarts" description="&lt;p>This instance is the mighty Hogwarts. Do you really need a description? Then maybe read the books or watch atleast the epic movies.&lt;/p>&#xA;">
           <ownedExtensions xsi:type="CapellaRequirements:CapellaOutgoingRelation"
@@ -3035,6 +3040,15 @@ The predator is far away</bodies>
           <ownedComponentExchanges xsi:type="org.polarsys.capella.core.data.fa:ComponentExchange"
               id="bcdee96b-9113-4388-858f-1bea7fa1d3b7" name="C 22" source="#60a1fd22-3ef8-46dd-8e0c-b4dbcca86ec0"
               target="#c06968be-09ae-4e9a-acc9-733c833a3c87" kind="FLOW"/>
+          <ownedComponentExchanges xsi:type="org.polarsys.capella.core.data.fa:ComponentExchange"
+              id="031de9d3-13ee-405c-93f1-81a42a9b1bf3" name="o1" source="#9fe7caff-fe85-46ea-8214-9820328aac73"
+              target="#4f111d67-92a8-4a39-845e-a0662401c889" kind="FLOW"/>
+          <ownedComponentExchanges xsi:type="org.polarsys.capella.core.data.fa:ComponentExchange"
+              id="1c050208-ea5e-403e-8987-5090dbcb0a02" name="o3" source="#5442bfe8-79d8-45b5-bf49-29f7f0c6f635"
+              target="#5ccac19c-76d3-405d-8fc3-85c8958dab45" kind="FLOW"/>
+          <ownedComponentExchanges xsi:type="org.polarsys.capella.core.data.fa:ComponentExchange"
+              id="8805a65b-d220-416d-ac04-b614cf7a8456" name="o4" source="#126c2f86-0fd5-4bc7-bdde-db32aadbd69c"
+              target="#b557cfc6-ca9a-40f5-b6f7-14e61523bd9a" kind="FLOW"/>
           <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="a3194240-cd17-4998-8f8b-785233487ec3"
               name="Campus" abstractType="#6583b560-6d2f-4190-baa2-94eef179c8ea"/>
           <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
@@ -3078,6 +3092,14 @@ The predator is far away</bodies>
               name="RightStack" abstractType="#e1e48763-7479-4f3a-8134-c82bb6705d58"/>
           <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="e721269a-87a2-4ae9-aa94-0f5376ef3461"
               name="MiddleStack" abstractType="#74af6883-25a0-446a-80f3-656f8a490b11"/>
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="92df1186-3cde-4e9e-9d6b-6609d006f36d"
+              name="Middle" abstractType="#16b4fcc5-548d-4721-b62a-d3d5b1c1d2eb"/>
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="8186a7ec-045a-433a-bece-672b767775fe"
+              name="Left 1" abstractType="#1c416771-64bc-4d0c-99eb-296ce27d0a35"/>
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="1a9e3f71-bf4d-442b-a3f3-9a97076f8390"
+              name="Right 1" abstractType="#c999f0f0-49d0-4b01-b260-f69dc63abbcb"/>
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="878e9589-a9f7-47b9-8fda-f009184716c5"
+              name="Right 2" abstractType="#ea3ff951-47ec-441e-aae6-c5103d47cf1a"/>
           <ownedComponentRealizations xsi:type="org.polarsys.capella.core.data.cs:ComponentRealization"
               id="df339fb7-b274-4439-ba44-8f112e408193" targetElement="#230c4621-7e0a-4d0a-9db2-d4ba5e97b3df"
               sourceElement="#0d2edb8f-fa34-4e73-89ec-fb9a63001440"/>
@@ -3424,6 +3446,61 @@ The predator is far away</bodies>
                 id="c06968be-09ae-4e9a-acc9-733c833a3c87" name="CP 18" orientation="IN"
                 kind="FLOW"/>
           </ownedLogicalComponents>
+          <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
+              id="16b4fcc5-548d-4721-b62a-d3d5b1c1d2eb" name="Middle">
+            <ownedComponentExchanges xsi:type="org.polarsys.capella.core.data.fa:ComponentExchange"
+                id="4a8f4058-3ef1-4e76-8c0f-41d45ed8f669" name="i1" source="#5d162922-7b14-4671-81ed-8fd2a240ae13"
+                target="#4f111d67-92a8-4a39-845e-a0662401c889" kind="FLOW"/>
+            <ownedComponentExchanges xsi:type="org.polarsys.capella.core.data.fa:ComponentExchange"
+                id="1b23d65b-44d4-4d19-808e-8eae5756dd90" name="i2" source="#126c2f86-0fd5-4bc7-bdde-db32aadbd69c"
+                target="#087cbba9-bc3c-4cfc-a004-0a6d2ea24696" kind="FLOW"/>
+            <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="9344f33d-d8e1-45f2-9fd9-4686d4a6cf83"
+                name="Inner 1" abstractType="#31bc2326-5a55-45f9-9967-f1957bcd3f89"/>
+            <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="68f12996-2024-4046-b6ac-76ce9c558ef4"
+                name="Inner 2" abstractType="#ad0bdf2f-bd0e-48bc-9296-5be3371a76e2"/>
+            <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+                id="4f111d67-92a8-4a39-845e-a0662401c889" name="CP 3" orientation="IN"
+                kind="FLOW"/>
+            <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+                id="0b558f0b-dd4a-4f35-ad88-f4abe44df415" name="CP 4" orientation="IN"
+                kind="FLOW"/>
+            <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+                id="5442bfe8-79d8-45b5-bf49-29f7f0c6f635" name="CP 5" orientation="OUT"
+                kind="FLOW"/>
+            <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+                id="126c2f86-0fd5-4bc7-bdde-db32aadbd69c" name="CP 6" orientation="OUT"
+                kind="FLOW"/>
+            <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
+                id="31bc2326-5a55-45f9-9967-f1957bcd3f89" name="Inner 1">
+              <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+                  id="5d162922-7b14-4671-81ed-8fd2a240ae13" name="CP 1" orientation="IN"
+                  kind="FLOW"/>
+            </ownedLogicalComponents>
+            <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
+                id="ad0bdf2f-bd0e-48bc-9296-5be3371a76e2" name="Inner 2">
+              <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+                  id="087cbba9-bc3c-4cfc-a004-0a6d2ea24696" name="CP 1" orientation="OUT"
+                  kind="FLOW"/>
+            </ownedLogicalComponents>
+          </ownedLogicalComponents>
+          <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
+              id="1c416771-64bc-4d0c-99eb-296ce27d0a35" name="Left 1">
+            <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+                id="9fe7caff-fe85-46ea-8214-9820328aac73" name="CP 1" orientation="OUT"
+                kind="FLOW"/>
+          </ownedLogicalComponents>
+          <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
+              id="c999f0f0-49d0-4b01-b260-f69dc63abbcb" name="Right 1">
+            <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+                id="5ccac19c-76d3-405d-8fc3-85c8958dab45" name="CP 1" orientation="IN"
+                kind="FLOW"/>
+          </ownedLogicalComponents>
+          <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
+              id="ea3ff951-47ec-441e-aae6-c5103d47cf1a" name="Right 2">
+            <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+                id="b557cfc6-ca9a-40f5-b6f7-14e61523bd9a" name="CP 1" orientation="IN"
+                kind="FLOW"/>
+          </ownedLogicalComponents>
           <ownedLogicalComponentPkgs xsi:type="org.polarsys.capella.core.data.la:LogicalComponentPkg"
               id="83d80c8a-e845-4fd9-bb6f-91fc32145785" name="LogicalComponents">
             <ownedComponentExchanges xsi:type="org.polarsys.capella.core.data.fa:ComponentExchange"
@@ -3568,6 +3645,12 @@ The predator is far away</bodies>
                 id="0fb6b5af-73a8-4b44-bd3f-541850b138ec" targetElement="#a596bcaf-605c-44ee-a420-073fbeb7574d"
                 sourceElement="#24c8b67b-9570-45f7-b383-c4a0b722b3b4"/>
           </ownedFeatures>
+        </ownedLogicalComponents>
+        <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
+            id="57635b74-b251-4b9b-8cc3-706dcc7b65db" name="Left 2" actor="true">
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+              id="3e0a3791-cc99-4af5-b789-5b33451ca743" name="CP 1" orientation="OUT"
+              kind="FLOW"/>
         </ownedLogicalComponents>
       </ownedLogicalComponentPkg>
       <ownedSystemAnalysisRealizations xsi:type="org.polarsys.capella.core.data.la:SystemAnalysisRealization"

--- a/tests/data/ContextDiagram.capella
+++ b/tests/data/ContextDiagram.capella
@@ -3447,7 +3447,7 @@ The predator is far away</bodies>
                 kind="FLOW"/>
           </ownedLogicalComponents>
           <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
-              id="16b4fcc5-548d-4721-b62a-d3d5b1c1d2eb" name="Middle">
+              id="16b4fcc5-548d-4721-b62a-d3d5b1c1d2eb" name="Hierarchy">
             <ownedComponentExchanges xsi:type="org.polarsys.capella.core.data.fa:ComponentExchange"
                 id="4a8f4058-3ef1-4e76-8c0f-41d45ed8f669" name="i1" source="#5d162922-7b14-4671-81ed-8fd2a240ae13"
                 target="#4f111d67-92a8-4a39-845e-a0662401c889" kind="FLOW"/>

--- a/tests/test_context_diagrams.py
+++ b/tests/test_context_diagrams.py
@@ -4,11 +4,13 @@
 import pathlib
 
 import capellambse
+from capellambse import diagram
 import pytest
 
 TEST_CAP_SIZING_UUID = "b996a45f-2954-4fdd-9141-7934e7687de6"
 TEST_HUMAN_ACTOR_SIZING_UUID = "e95847ae-40bb-459e-8104-7209e86ea2d1"
 TEST_ACTOR_SIZING_UUID = "6c8f32bf-0316-477f-a23b-b5239624c28d"
+TEST_HIERARCHY_UUID = "16b4fcc5-548d-4721-b62a-d3d5b1c1d2eb"
 
 
 @pytest.mark.parametrize(
@@ -123,3 +125,18 @@ def test_context_diagrams_symbol_sizing(
     assert adiag[TEST_CAP_SIZING_UUID].size.y >= 92
     assert adiag[TEST_HUMAN_ACTOR_SIZING_UUID].size.y >= 57
     assert adiag[TEST_ACTOR_SIZING_UUID].size.y >= 37
+
+
+def test_hierarchy_in_context_diagram(model: capellambse.MelodyModel) -> None:
+    obj = model.by_uuid(TEST_HIERARCHY_UUID)
+    expected_children = {
+        "31bc2326-5a55-45f9-9967-f1957bcd3f89",
+        "ad0bdf2f-bd0e-48bc-9296-5be3371a76e2",
+    }
+
+    adiag = obj.context_diagram.render(None)
+
+    children = {obj.uuid for obj in adiag[TEST_HIERARCHY_UUID].children}
+
+    for uuid in expected_children:
+        assert uuid in children

--- a/tests/test_context_diagrams.py
+++ b/tests/test_context_diagrams.py
@@ -4,7 +4,6 @@
 import pathlib
 
 import capellambse
-from capellambse import diagram
 import pytest
 
 TEST_CAP_SIZING_UUID = "b996a45f-2954-4fdd-9141-7934e7687de6"


### PR DESCRIPTION
Hierarchy support and handling:
![image](https://user-images.githubusercontent.com/50786483/228511603-b96c918c-64dd-4eb6-9acc-f6229cfcb495.png)

Identified a bug: False direction for `ComponentExchanges` when changing direction of ports. Direction needs to be checked and patched against direction of ports.