### PR TITLE
fix(serializers): Remove unnecessary condition

### DIFF
--- a/capellambse_context_diagrams/serializers.py
+++ b/capellambse_context_diagrams/serializers.py
@@ -117,7 +117,6 @@ class DiagramSerializer:
             box_type = ("box", "symbol")[
                 is_port
                 or has_symbol_cls
-                and not self._diagram.target == obj
                 and not self._diagram.display_symbols_as_boxes
             ]
 


### PR DESCRIPTION
The diagram.target (centerbox) was ignored on the symbol-conversion. This wasn't the wanted behavior for `display_symbols_as_boxes`.

Closes #41.