### PR TITLE
Feat class tree

### DIFF
--- a/capellambse_context_diagrams/__init__.py
+++ b/capellambse_context_diagrams/__init__.py
@@ -24,7 +24,7 @@ from importlib import metadata
 
 from capellambse.diagram import COLORS, CSSdef, capstyle
 from capellambse.model import common
-from capellambse.model.crosslayer import fa
+from capellambse.model.crosslayer import fa, information
 from capellambse.model.layers import ctx, la, oa, pa
 from capellambse.model.modeltypes import DiagramType
 
@@ -47,6 +47,7 @@ def init() -> None:
     """Initialize the extension."""
     register_classes()
     register_interface_context()
+    register_class_tree()
     # register_functional_context() XXX: Future
 
 
@@ -148,3 +149,12 @@ def register_functional_context() -> None:
             attr_name,
             context.FunctionalContextAccessor(dgcls.value),
         )
+
+
+def register_class_tree() -> None:
+    """Add the `class_tree_diagram` attribute to `ModelObject`s."""
+    common.set_accessor(
+        information.Class,
+        "class_tree_diagram",
+        context.ClassTreeAccessor(DiagramType.CDB.value),
+    )

--- a/capellambse_context_diagrams/collectors/class_tree.py
+++ b/capellambse_context_diagrams/collectors/class_tree.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+# SPDX-License-Identifier: Apache-2.0
+"""This submodule defines the collector for the Class-Tree diagram."""
+from __future__ import annotations
+
+import collections.abc as cabc
+import typing as t
+
+from capellambse import helpers
+from capellambse.model.crosslayer import information
+
+from .. import _elkjs, context
+from . import generic, makers
+
+LAYOUT_OPTIONS: _elkjs.LayoutOptions = {
+    "algorithm": "layered",
+    "edgeRouting": "ORTHOGONAL",
+    "elk.direction": "DOWN",
+    "partitioning.activate": True,
+    "edgeLabels.sideSelection": "ALWAYS_DOWN",
+}
+
+
+def collector(
+    diagram: context.ContextDiagram, params: dict[str, t.Any] | None = None
+) -> _elkjs.ELKInputData:
+    """Return the class tree data for ELK."""
+    assert isinstance(diagram.target, information.Class)
+    data = generic.collector(diagram, no_symbol=True)
+    data["children"][0]["layoutOptions"] = {}
+    data["children"][0]["layoutOptions"]["elk.partitioning.partition"] = 0
+    data["layoutOptions"] = LAYOUT_OPTIONS
+    data["layoutOptions"]["algorithm"] = (params or {})["algorithm"]
+    data["layoutOptions"]["elk.direction"] = (params or {})["direction"]
+    data["layoutOptions"]["edgeRouting"] = (params or {})["edgeRouting"]
+
+    made_boxes: set[str] = set()
+    for uid, (source, target) in get_all_classes(diagram.target):
+        property_uuid, text, partition = uid.split(" ")[1:4]
+        if target.uuid not in made_boxes:
+            made_boxes.add(target.uuid)
+            box = makers.make_box(target)
+            box["layoutOptions"] = {}
+            box["layoutOptions"]["elk.partitioning.partition"] = int(partition)
+            data["children"].append(box)
+
+        width, height = helpers.extent_func(text)
+        label: _elkjs.ELKInputLabel = {
+            "text": text,
+            "width": width + 2 * makers.LABEL_HPAD,
+            "height": height + 2 * makers.LABEL_VPAD,
+        }
+        data["edges"].append(
+            {
+                "id": property_uuid,
+                "sources": [source.uuid],
+                "targets": [target.uuid],
+                "labels": [label],
+            }
+        )
+    return data
+
+
+def get_all_classes(
+    root: information.Class, partition: int = 0
+) -> cabc.Iterator[tuple[str, tuple[information.Class, information.Class]]]:
+    """Yield all classes of the class tree."""
+    partition += 1
+    classes: dict[str, tuple[information.Class, information.Class]] = {}
+    for prop in root.properties:
+        if prop.type.xtype.endswith("Class"):
+            edge_id = f"{root.name} {prop.uuid} {prop.name}"
+            edge_id = f"{edge_id} {partition} {prop.type.name}"
+            if edge_id not in classes:
+                classes[edge_id] = (root, prop.type)
+                classes.update(dict(get_all_classes(prop.type)))
+
+    yield from classes.items()

--- a/capellambse_context_diagrams/context.py
+++ b/capellambse_context_diagrams/context.py
@@ -350,5 +350,6 @@ class ClassTreeDiagram(ContextDiagram):
         params.setdefault("algorithm", "layered")
         params.setdefault("direction", "DOWN")
         params.setdefault("edgeRouting", "POLYLINE")
+        params.setdefault("partitioning", True)
         params["elkdata"] = class_tree.collector(self, params)
         return super()._create_diagram(params)

--- a/capellambse_context_diagrams/context.py
+++ b/capellambse_context_diagrams/context.py
@@ -15,7 +15,7 @@ from capellambse import diagram as cdiagram
 from capellambse.model import common, diagram, modeltypes
 
 from . import _elkjs, filters, serializers, styling
-from .collectors import exchanges, get_elkdata
+from .collectors import class_tree, exchanges, get_elkdata
 
 logger = logging.getLogger(__name__)
 
@@ -127,6 +127,26 @@ class FunctionalContextAccessor(ContextAccessor):
         return self._get(
             obj, FunctionalContextDiagram, "{}_functional_context"
         )
+
+
+class ClassTreeAccessor(ContextAccessor):
+    """Provides access to the class tree diagrams."""
+
+    # pylint: disable=super-init-not-called
+    def __init__(self, diagclass: str) -> None:
+        self._dgcls = diagclass
+
+    def __get__(  # type: ignore
+        self,
+        obj: common.T | None,
+        objtype: type | None = None,
+    ) -> common.Accessor | ContextDiagram:
+        """Make a ContextDiagram for the given model object."""
+        del objtype
+        if obj is None:  # pragma: no cover
+            return self
+        assert isinstance(obj, common.GenericElement)
+        return self._get(obj, ClassTreeDiagram, "{}_class_tree")
 
 
 class ContextDiagram(diagram.AbstractDiagram):
@@ -304,4 +324,31 @@ class FunctionalContextDiagram(ContextDiagram):
         params["elkdata"] = exchanges.get_elkdata_for_exchanges(
             self, exchanges.FunctionalContextCollector, params
         )
+        return super()._create_diagram(params)
+
+
+class ClassTreeDiagram(ContextDiagram):
+    """An automatically generated ClassTree Diagram.
+
+    This diagram is exclusively for ``Class``es.
+    """
+
+    def __init__(self, class_: str, obj: common.GenericElement, **kw) -> None:
+        super().__init__(class_, obj, **kw, display_symbols_as_boxes=True)
+
+    @property
+    def uuid(self) -> str:  # type: ignore
+        """Returns the UUID of the diagram."""
+        return f"{self.target.uuid}_class-tree"
+
+    @property
+    def name(self) -> str:  # type: ignore
+        """Returns the name of the diagram."""
+        return f"Class Tree of {self.target.name}"
+
+    def _create_diagram(self, params: dict[str, t.Any]) -> cdiagram.Diagram:
+        params.setdefault("algorithm", "layered")
+        params.setdefault("direction", "DOWN")
+        params.setdefault("edgeRouting", "POLYLINE")
+        params["elkdata"] = class_tree.collector(self, params)
         return super()._create_diagram(params)

--- a/capellambse_context_diagrams/serializers.py
+++ b/capellambse_context_diagrams/serializers.py
@@ -28,6 +28,8 @@ Elk types can be one of the following types:
 * `junction`.
 """
 
+REMAP_STYLECLASS: dict[str, str] = {"Property": "Association"}
+
 
 class DiagramSerializer:
     """Serialize an ``elk_diagram`` into an
@@ -47,7 +49,7 @@ class DiagramSerializer:
     def __init__(self, elk_diagram: context.ContextDiagram) -> None:
         self.model = elk_diagram.target._model
         self._diagram = elk_diagram
-        self._cache: dict[str, diagram.Box] = {}
+        self._cache: dict[str, diagram.Box | diagram.Edge] = {}
 
     def make_diagram(self, data: _elkjs.ELKOutputData) -> diagram.Diagram:
         """Transform a layouted diagram into an `diagram.Diagram`.
@@ -136,6 +138,7 @@ class DiagramSerializer:
             self.diagram.add_element(element)
             self._cache[child["id"]] = element
         elif child["type"] == "edge":
+            styleclass = REMAP_STYLECLASS.get(styleclass, styleclass)  # type: ignore[arg-type]
             element = diagram.Edge(
                 [
                     ref + (point["x"], point["y"])

--- a/capellambse_context_diagrams/serializers.py
+++ b/capellambse_context_diagrams/serializers.py
@@ -28,7 +28,7 @@ Elk types can be one of the following types:
 * `junction`.
 """
 
-REMAP_STYLECLASS: dict[str, str] = {"Property": "Association"}
+REMAP_STYLECLASS: dict[str, str] = {"Unset": "Association"}
 
 
 class DiagramSerializer:

--- a/tests/data/ContextDiagram.aird
+++ b/tests/data/ContextDiagram.aird
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:concern="http://www.eclipse.org/sirius/diagram/description/concern/1.1.0" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:description_1="http://www.eclipse.org/sirius/diagram/description/1.1.0" xmlns:diagram="http://www.eclipse.org/sirius/diagram/1.1.0" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:filter="http://www.eclipse.org/sirius/diagram/description/filter/1.1.0" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.3/notation" xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/5.0.0" xmlns:org.polarsys.capella.core.data.ctx="http://www.polarsys.org/capella/core/ctx/5.0.0" xmlns:org.polarsys.capella.core.data.fa="http://www.polarsys.org/capella/core/fa/5.0.0" xmlns:org.polarsys.capella.core.data.information="http://www.polarsys.org/capella/core/information/5.0.0" xmlns:org.polarsys.capella.core.data.interaction="http://www.polarsys.org/capella/core/interaction/5.0.0" xmlns:org.polarsys.capella.core.data.la="http://www.polarsys.org/capella/core/la/5.0.0" xmlns:org.polarsys.capella.core.data.oa="http://www.polarsys.org/capella/core/oa/5.0.0" xmlns:style="http://www.eclipse.org/sirius/diagram/description/style/1.1.0" xmlns:viewpoint="http://www.eclipse.org/sirius/1.1.0" xsi:schemaLocation="http://www.eclipse.org/sirius/diagram/description/concern/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/concern http://www.eclipse.org/sirius/description/1.1.0 http://www.eclipse.org/sirius/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/filter/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/filter http://www.eclipse.org/sirius/diagram/description/style/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/style">
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:concern="http://www.eclipse.org/sirius/diagram/description/concern/1.1.0" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:description_1="http://www.eclipse.org/sirius/diagram/description/1.1.0" xmlns:diagram="http://www.eclipse.org/sirius/diagram/1.1.0" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:filter="http://www.eclipse.org/sirius/diagram/description/filter/1.1.0" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.3/notation" xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/5.0.0" xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/5.0.0" xmlns:org.polarsys.capella.core.data.ctx="http://www.polarsys.org/capella/core/ctx/5.0.0" xmlns:org.polarsys.capella.core.data.fa="http://www.polarsys.org/capella/core/fa/5.0.0" xmlns:org.polarsys.capella.core.data.information="http://www.polarsys.org/capella/core/information/5.0.0" xmlns:org.polarsys.capella.core.data.interaction="http://www.polarsys.org/capella/core/interaction/5.0.0" xmlns:org.polarsys.capella.core.data.la="http://www.polarsys.org/capella/core/la/5.0.0" xmlns:org.polarsys.capella.core.data.oa="http://www.polarsys.org/capella/core/oa/5.0.0" xmlns:style="http://www.eclipse.org/sirius/diagram/description/style/1.1.0" xmlns:viewpoint="http://www.eclipse.org/sirius/1.1.0" xsi:schemaLocation="http://www.eclipse.org/sirius/diagram/description/concern/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/concern http://www.eclipse.org/sirius/description/1.1.0 http://www.eclipse.org/sirius/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/filter/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/filter http://www.eclipse.org/sirius/diagram/description/style/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/style">
   <viewpoint:DAnalysis uid="_-kLykKDzEeqf7Mw7EIo_Ew" selectedViews="_-mtiIKDzEeqf7Mw7EIo_Ew __FJxoKDzEeqf7Mw7EIo_Ew __FtLQKDzEeqf7Mw7EIo_Ew __PkR4KDzEeqf7Mw7EIo_Ew __RBqcKDzEeqf7Mw7EIo_Ew __SVSAKDzEeqf7Mw7EIo_Ew __S3dgKDzEeqf7Mw7EIo_Ew __THVIKDzEeqf7Mw7EIo_Ew _4Dt18PHWEeq9N-vcO9FSUw _4F-fwPHWEeq9N-vcO9FSUw" version="14.6.0.202110251100">
     <semanticResources>ContextDiagram.afm</semanticResources>
     <semanticResources>ContextDiagram.capella</semanticResources>
@@ -8,6 +8,10 @@
     </ownedViews>
     <ownedViews xmi:type="viewpoint:DView" uid="__FJxoKDzEeqf7Mw7EIo_Ew">
       <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']"/>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_OmRFoGwfEe6iyfecRwAuGw" name="[CDB] Data" repPath="#_OmIiwGwfEe6iyfecRwAuGw" changeId="ad440e9a-12c4-4b5d-9bdd-b4c2cce19b7e">
+        <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']"/>
+        <target xmi:type="org.polarsys.capella.core.data.information:DataPkg" href="ContextDiagram.capella#d12c04b6-392f-4761-be5a-e44c688823f6"/>
+      </ownedRepresentationDescriptors>
     </ownedViews>
     <ownedViews xmi:type="viewpoint:DView" uid="__FtLQKDzEeqf7Mw7EIo_Ew">
       <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']"/>
@@ -7977,5 +7981,214 @@
     <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer"/>
     <activatedLayers xmi:type="description_1:AdditionalLayer" href="platform:/plugin/org.polarsys.capella.vp.requirements.design/description/CapellaRequirements.odesign#//@ownedViewpoints[name='CapellaRequirements_ID']/@ownedRepresentationExtensions[name='CapellaViewpoints']/@layers[name='ReqVP_Requirements_Layer']"/>
     <target xmi:type="org.polarsys.capella.core.data.la:LogicalComponentPkg" href="ContextDiagram.capella#84c0978d-9a32-4f5b-8013-5b0b6adbfd73"/>
+  </diagram:DSemanticDiagram>
+  <diagram:DSemanticDiagram uid="_OmIiwGwfEe6iyfecRwAuGw">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_OmWlMGwfEe6iyfecRwAuGw" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_OmWlMWwfEe6iyfecRwAuGw" type="Sirius" element="_OmIiwGwfEe6iyfecRwAuGw" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_PLddYGwfEe6iyfecRwAuGw" type="2003" element="_PK-VMGwfEe6iyfecRwAuGw">
+          <children xmi:type="notation:Node" xmi:id="_PLergGwfEe6iyfecRwAuGw" type="5007"/>
+          <children xmi:type="notation:Node" xmi:id="_PLergWwfEe6iyfecRwAuGw" type="7004">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_PLergmwfEe6iyfecRwAuGw"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_PLerg2wfEe6iyfecRwAuGw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_PLddYWwfEe6iyfecRwAuGw" fontName="Fira Code" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PLddYmwfEe6iyfecRwAuGw" x="360" y="140" width="323" height="63"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_RGnigGwfEe6iyfecRwAuGw" type="2003" element="_RGCTsGwfEe6iyfecRwAuGw">
+          <children xmi:type="notation:Node" xmi:id="_RGoJkGwfEe6iyfecRwAuGw" type="5007"/>
+          <children xmi:type="notation:Node" xmi:id="_RGoJkWwfEe6iyfecRwAuGw" type="7004">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_RGoJkmwfEe6iyfecRwAuGw"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_RGoJk2wfEe6iyfecRwAuGw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_RGnigWwfEe6iyfecRwAuGw" fontName="Fira Code" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RGnigmwfEe6iyfecRwAuGw" x="440" y="290"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_S4AAkGwfEe6iyfecRwAuGw" type="2003" element="_S3axwGwfEe6iyfecRwAuGw">
+          <children xmi:type="notation:Node" xmi:id="_S4AnoGwfEe6iyfecRwAuGw" type="5007"/>
+          <children xmi:type="notation:Node" xmi:id="_S4AnoWwfEe6iyfecRwAuGw" type="7004">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_S4AnomwfEe6iyfecRwAuGw"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_S4Ano2wfEe6iyfecRwAuGw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_S4AAkWwfEe6iyfecRwAuGw" fontName="Fira Code" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_S4AAkmwfEe6iyfecRwAuGw" x="510" y="310"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_UHt8AGwfEe6iyfecRwAuGw" type="2003" element="_UHJUQGwfEe6iyfecRwAuGw">
+          <children xmi:type="notation:Node" xmi:id="_UHujEGwfEe6iyfecRwAuGw" type="5007"/>
+          <children xmi:type="notation:Node" xmi:id="_UHujEWwfEe6iyfecRwAuGw" type="7004">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_UHujEmwfEe6iyfecRwAuGw"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_UHujE2wfEe6iyfecRwAuGw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_UHt8AWwfEe6iyfecRwAuGw" fontName="Fira Code" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UHt8AmwfEe6iyfecRwAuGw" x="561" y="420"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_OmWlMmwfEe6iyfecRwAuGw"/>
+        <edges xmi:type="notation:Edge" xmi:id="_4vzTMGwfEe6iyfecRwAuGw" type="4001" element="_4vKaAGwfEe6iyfecRwAuGw" source="_PLddYGwfEe6iyfecRwAuGw" target="_RGnigGwfEe6iyfecRwAuGw">
+          <children xmi:type="notation:Node" xmi:id="_4vz6QGwfEe6iyfecRwAuGw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4vz6QWwfEe6iyfecRwAuGw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_4vz6QmwfEe6iyfecRwAuGw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4vz6Q2wfEe6iyfecRwAuGw" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_4v0hUGwfEe6iyfecRwAuGw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4v0hUWwfEe6iyfecRwAuGw" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_4vzTMWwfEe6iyfecRwAuGw" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_4vzTMmwfEe6iyfecRwAuGw" fontName="Fira Code" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_4vzTM2wfEe6iyfecRwAuGw" points="[0, 0, 0, -89]$[0, 89, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4v1vcGwfEe6iyfecRwAuGw" id="(0.3146417445482866,1.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4v1vcWwfEe6iyfecRwAuGw" id="(0.5,0.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_5ovGUGwfEe6iyfecRwAuGw" type="4001" element="_5oHbQGwfEe6iyfecRwAuGw" source="_PLddYGwfEe6iyfecRwAuGw" target="_S4AAkGwfEe6iyfecRwAuGw">
+          <children xmi:type="notation:Node" xmi:id="_5ovtYGwfEe6iyfecRwAuGw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5ovtYWwfEe6iyfecRwAuGw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_5ovtYmwfEe6iyfecRwAuGw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5ovtY2wfEe6iyfecRwAuGw" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_5ovtZGwfEe6iyfecRwAuGw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5ovtZWwfEe6iyfecRwAuGw" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_5ovGUWwfEe6iyfecRwAuGw" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_5ovGUmwfEe6iyfecRwAuGw" fontName="Fira Code" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5ovGU2wfEe6iyfecRwAuGw" points="[0, 0, 0, -109]$[0, 109, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5ovtZmwfEe6iyfecRwAuGw" id="(0.5327102803738317,1.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5ovtZ2wfEe6iyfecRwAuGw" id="(0.5,0.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_6ZMS4GwfEe6iyfecRwAuGw" type="4001" element="_6YiyqGwfEe6iyfecRwAuGw" source="_S4AAkGwfEe6iyfecRwAuGw" target="_UHt8AGwfEe6iyfecRwAuGw">
+          <children xmi:type="notation:Node" xmi:id="_6ZMS5GwfEe6iyfecRwAuGw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6ZMS5WwfEe6iyfecRwAuGw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_6ZM58GwfEe6iyfecRwAuGw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6ZM58WwfEe6iyfecRwAuGw" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_6ZM58mwfEe6iyfecRwAuGw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6ZM582wfEe6iyfecRwAuGw" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_6ZMS4WwfEe6iyfecRwAuGw" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_6ZMS4mwfEe6iyfecRwAuGw" fontName="Fira Code" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6ZMS42wfEe6iyfecRwAuGw" points="[0, 0, -40, -71]$[40, 71, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6ZM59GwfEe6iyfecRwAuGw" id="(0.7142857142857143,1.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6ZM59WwfEe6iyfecRwAuGw" id="(0.3392857142857143,0.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_72IK8GwfEe6iyfecRwAuGw" type="4001" element="_71iVEGwfEe6iyfecRwAuGw" source="_PLddYGwfEe6iyfecRwAuGw" target="_UHt8AGwfEe6iyfecRwAuGw">
+          <children xmi:type="notation:Node" xmi:id="_72IyAGwfEe6iyfecRwAuGw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_72IyAWwfEe6iyfecRwAuGw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_72IyAmwfEe6iyfecRwAuGw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_72IyA2wfEe6iyfecRwAuGw" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_72IyBGwfEe6iyfecRwAuGw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_72IyBWwfEe6iyfecRwAuGw" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_72IK8WwfEe6iyfecRwAuGw" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_72IK8mwfEe6iyfecRwAuGw" fontName="Fira Code" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_72IK82wfEe6iyfecRwAuGw" points="[0, 0, 0, -219]$[0, 219, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_72IyBmwfEe6iyfecRwAuGw" id="(0.778816199376947,1.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_72IyB2wfEe6iyfecRwAuGw" id="(0.875,0.0)"/>
+        </edges>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_Om5XwGwfEe6iyfecRwAuGw" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_Om5XwWwfEe6iyfecRwAuGw"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_PK-VMGwfEe6iyfecRwAuGw" name="Root" outgoingEdges="_4vKaAGwfEe6iyfecRwAuGw _5oHbQGwfEe6iyfecRwAuGw _71iVEGwfEe6iyfecRwAuGw">
+      <target xmi:type="org.polarsys.capella.core.data.information:Class" href="ContextDiagram.capella#b7c7f442-377f-492c-90bf-331e66988bda"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.information:Class" href="ContextDiagram.capella#b7c7f442-377f-492c-90bf-331e66988bda"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_PK_jUGwfEe6iyfecRwAuGw" borderSize="1" borderSizeComputationExpression="1" borderColor="123,105,79" backgroundStyle="Liquid" foregroundColor="232,224,210">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@defaultLayer/@containerMappings[name='DT_Class']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@defaultLayer/@containerMappings[name='DT_Class']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_RGCTsGwfEe6iyfecRwAuGw" name="One" incomingEdges="_4vKaAGwfEe6iyfecRwAuGw">
+      <target xmi:type="org.polarsys.capella.core.data.information:Class" href="ContextDiagram.capella#0093ffdd-ab4d-4c87-971d-0c2fc1a0b094"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.information:Class" href="ContextDiagram.capella#0093ffdd-ab4d-4c87-971d-0c2fc1a0b094"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_RGC6wGwfEe6iyfecRwAuGw" borderSize="1" borderSizeComputationExpression="1" borderColor="123,105,79" backgroundStyle="Liquid" foregroundColor="232,224,210">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@defaultLayer/@containerMappings[name='DT_Class']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@defaultLayer/@containerMappings[name='DT_Class']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_S3axwGwfEe6iyfecRwAuGw" name="Two" outgoingEdges="_6YiyqGwfEe6iyfecRwAuGw" incomingEdges="_5oHbQGwfEe6iyfecRwAuGw">
+      <target xmi:type="org.polarsys.capella.core.data.information:Class" href="ContextDiagram.capella#1dccccde-6ab1-47ac-8ee8-a3033a49a9e5"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.information:Class" href="ContextDiagram.capella#1dccccde-6ab1-47ac-8ee8-a3033a49a9e5"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_S3bY0GwfEe6iyfecRwAuGw" borderSize="1" borderSizeComputationExpression="1" borderColor="123,105,79" backgroundStyle="Liquid" foregroundColor="232,224,210">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@defaultLayer/@containerMappings[name='DT_Class']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@defaultLayer/@containerMappings[name='DT_Class']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_UHJUQGwfEe6iyfecRwAuGw" name="Three" incomingEdges="_6YiyqGwfEe6iyfecRwAuGw _71iVEGwfEe6iyfecRwAuGw">
+      <target xmi:type="org.polarsys.capella.core.data.information:Class" href="ContextDiagram.capella#322dc599-ea72-49e9-8e37-fe5226e41f19"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.information:Class" href="ContextDiagram.capella#322dc599-ea72-49e9-8e37-fe5226e41f19"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_UHJ7UGwfEe6iyfecRwAuGw" borderSize="1" borderSizeComputationExpression="1" borderColor="123,105,79" backgroundStyle="Liquid" foregroundColor="232,224,210">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@defaultLayer/@containerMappings[name='DT_Class']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@defaultLayer/@containerMappings[name='DT_Class']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_4vKaAGwfEe6iyfecRwAuGw" name=" " sourceNode="_PK-VMGwfEe6iyfecRwAuGw" targetNode="_RGCTsGwfEe6iyfecRwAuGw" endLabel="one">
+      <target xmi:type="org.polarsys.capella.core.data.information:Association" href="ContextDiagram.capella#11d42718-70a0-455b-af59-dbf87d50a885"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.information:Association" href="ContextDiagram.capella#11d42718-70a0-455b-af59-dbf87d50a885"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.information:Property" href="ContextDiagram.capella#3e01cf5b-0f4c-4295-8c53-809c7c272123"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.information:Property" href="ContextDiagram.capella#54163757-6f40-441e-9a02-cc79c2cab404"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_4vMPMGwfEe6iyfecRwAuGw" strokeColor="0,0,0">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@defaultLayer/@edgeMappings[name='DT_Association']/@conditionnalStyles.0/@style"/>
+        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" uid="_4vMPMWwfEe6iyfecRwAuGw" showIcon="false"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_4vMPM2wfEe6iyfecRwAuGw"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_4vMPMmwfEe6iyfecRwAuGw" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@defaultLayer/@edgeMappings[name='DT_Association']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_5oHbQGwfEe6iyfecRwAuGw" name=" " sourceNode="_PK-VMGwfEe6iyfecRwAuGw" targetNode="_S3axwGwfEe6iyfecRwAuGw" endLabel="two">
+      <target xmi:type="org.polarsys.capella.core.data.information:Association" href="ContextDiagram.capella#23211949-9b66-4033-93f9-a40bf103d519"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.information:Association" href="ContextDiagram.capella#23211949-9b66-4033-93f9-a40bf103d519"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.information:Property" href="ContextDiagram.capella#7d18b138-72f7-43dd-b589-0f3401f532ad"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.information:Property" href="ContextDiagram.capella#604aa239-6be0-4867-82fd-85f83213151d"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_5oLssGwfEe6iyfecRwAuGw" sourceArrow="Diamond" strokeColor="0,0,0">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@defaultLayer/@edgeMappings[name='DT_Association']/@conditionnalStyles.12/@style"/>
+        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" uid="_5oLssWwfEe6iyfecRwAuGw" showIcon="false"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_5oLss2wfEe6iyfecRwAuGw"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_5oLssmwfEe6iyfecRwAuGw" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@defaultLayer/@edgeMappings[name='DT_Association']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_6YiyqGwfEe6iyfecRwAuGw" name=" " sourceNode="_S3axwGwfEe6iyfecRwAuGw" targetNode="_UHJUQGwfEe6iyfecRwAuGw" endLabel="three">
+      <target xmi:type="org.polarsys.capella.core.data.information:Association" href="ContextDiagram.capella#1de298dd-ccef-4505-9a5e-1aa792f2eb19"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.information:Association" href="ContextDiagram.capella#1de298dd-ccef-4505-9a5e-1aa792f2eb19"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.information:Property" href="ContextDiagram.capella#c7511550-1513-4382-9768-20bb1ca621db"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.information:Property" href="ContextDiagram.capella#7ded1791-1b15-4cbc-9e2a-a711a32c9de2"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_6Ykn0GwfEe6iyfecRwAuGw" sourceArrow="FillDiamond" strokeColor="0,0,0">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@defaultLayer/@edgeMappings[name='DT_Association']/@conditionnalStyles.16/@style"/>
+        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" uid="_6Ykn0WwfEe6iyfecRwAuGw" showIcon="false"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_6Ykn02wfEe6iyfecRwAuGw"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_6Ykn0mwfEe6iyfecRwAuGw" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@defaultLayer/@edgeMappings[name='DT_Association']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_71iVEGwfEe6iyfecRwAuGw" sourceNode="_PK-VMGwfEe6iyfecRwAuGw" targetNode="_UHJUQGwfEe6iyfecRwAuGw">
+      <target xmi:type="org.polarsys.capella.core.data.capellacore:Generalization" href="ContextDiagram.capella#a8828afb-fa24-44a8-942e-2665dbcf9405"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.capellacore:Generalization" href="ContextDiagram.capella#a8828afb-fa24-44a8-942e-2665dbcf9405"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_71iVEWwfEe6iyfecRwAuGw" targetArrow="InputClosedArrow" strokeColor="0,0,0">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@defaultLayer/@edgeMappings[name='DT_Generalization']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_71iVEmwfEe6iyfecRwAuGw" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@defaultLayer/@edgeMappings[name='DT_Generalization']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']"/>
+    <currentConcern xmi:type="concern:ConcernDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@concerns/@ownedConcernDescriptions.0"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@filters[name='hide.association.labels.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@filters[name='hide.technical.interfaces.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_OmJw4GwfEe6iyfecRwAuGw"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@defaultLayer"/>
+    <activatedLayers xmi:type="description_1:AdditionalLayer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@additionalLayers[name='Communication%20Model']"/>
+    <activatedLayers xmi:type="description_1:AdditionalLayer" href="platform:/plugin/org.polarsys.capella.vp.requirements.design/description/CapellaRequirements.odesign#//@ownedViewpoints[name='CapellaRequirements_ID']/@ownedRepresentationExtensions[name='CapellaViewpoints']/@layers[name='ReqVP_Requirements_Layer']"/>
+    <target xmi:type="org.polarsys.capella.core.data.information:DataPkg" href="ContextDiagram.capella#d12c04b6-392f-4761-be5a-e44c688823f6"/>
   </diagram:DSemanticDiagram>
 </xmi:XMI>

--- a/tests/data/ContextDiagram.capella
+++ b/tests/data/ContextDiagram.capella
@@ -768,8 +768,78 @@ The predator is far away</bodies>
             id="e3ccf45c-d714-40cd-9261-21f5b79f1a77" name="good advise" exchangeMechanism="FLOW"/>
         <ownedExchangeItems xsi:type="org.polarsys.capella.core.data.information:ExchangeItem"
             id="fed1cc38-6dcd-45f3-bcd9-66177f33afee" name="not so good advise" exchangeMechanism="FLOW"/>
+        <ownedAssociations xsi:type="org.polarsys.capella.core.data.information:Association"
+            id="11d42718-70a0-455b-af59-dbf87d50a885" name="DataAssociation1" navigableMembers="#54163757-6f40-441e-9a02-cc79c2cab404">
+          <ownedMembers xsi:type="org.polarsys.capella.core.data.information:Property"
+              id="3e01cf5b-0f4c-4295-8c53-809c7c272123" name="root" abstractType="#b7c7f442-377f-492c-90bf-331e66988bda"
+              aggregationKind="ASSOCIATION">
+            <ownedMinCard xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="ae99da67-ac84-4fac-830c-dfee3c65c406" value="1"/>
+            <ownedMaxCard xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="2648b2fd-61b5-424c-9386-dffe775c5413" value="1"/>
+          </ownedMembers>
+        </ownedAssociations>
+        <ownedAssociations xsi:type="org.polarsys.capella.core.data.information:Association"
+            id="23211949-9b66-4033-93f9-a40bf103d519" name="DataAssociation2" navigableMembers="#604aa239-6be0-4867-82fd-85f83213151d">
+          <ownedMembers xsi:type="org.polarsys.capella.core.data.information:Property"
+              id="7d18b138-72f7-43dd-b589-0f3401f532ad" name="root" abstractType="#b7c7f442-377f-492c-90bf-331e66988bda"
+              aggregationKind="ASSOCIATION">
+            <ownedMinCard xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="f82c037b-b6d3-4f71-aee1-c946b4a8d816" value="1"/>
+            <ownedMaxCard xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="9008c153-ac8a-4a0c-87e8-9ba30edb170f" value="1"/>
+          </ownedMembers>
+        </ownedAssociations>
+        <ownedAssociations xsi:type="org.polarsys.capella.core.data.information:Association"
+            id="1de298dd-ccef-4505-9a5e-1aa792f2eb19" name="DataAssociation3" navigableMembers="#7ded1791-1b15-4cbc-9e2a-a711a32c9de2">
+          <ownedMembers xsi:type="org.polarsys.capella.core.data.information:Property"
+              id="c7511550-1513-4382-9768-20bb1ca621db" name="two" abstractType="#1dccccde-6ab1-47ac-8ee8-a3033a49a9e5"
+              aggregationKind="ASSOCIATION">
+            <ownedMinCard xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="75abc724-4993-48fa-8538-aeabdbdd12e6" value="1"/>
+            <ownedMaxCard xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="e602823b-c2dc-4f77-a0fd-109956ace053" value="1"/>
+          </ownedMembers>
+        </ownedAssociations>
         <ownedClasses xsi:type="org.polarsys.capella.core.data.information:Class"
             id="8164ae8b-36d5-4502-a184-5ec064db4ec3" name="Twist"/>
+        <ownedClasses xsi:type="org.polarsys.capella.core.data.information:Class"
+            id="b7c7f442-377f-492c-90bf-331e66988bda" name="Root">
+          <ownedGeneralizations xsi:type="org.polarsys.capella.core.data.capellacore:Generalization"
+              id="a8828afb-fa24-44a8-942e-2665dbcf9405" super="#322dc599-ea72-49e9-8e37-fe5226e41f19"
+              sub="#b7c7f442-377f-492c-90bf-331e66988bda"/>
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.information:Property"
+              id="54163757-6f40-441e-9a02-cc79c2cab404" name="one" abstractType="#0093ffdd-ab4d-4c87-971d-0c2fc1a0b094"
+              aggregationKind="ASSOCIATION">
+            <ownedMinCard xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="343fffe9-810a-40cf-8559-528e8a6c7313" value="1"/>
+            <ownedMaxCard xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="319c1319-41f2-4584-8597-1e781ff77bd7" value="1"/>
+          </ownedFeatures>
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.information:Property"
+              id="604aa239-6be0-4867-82fd-85f83213151d" name="two" abstractType="#1dccccde-6ab1-47ac-8ee8-a3033a49a9e5"
+              aggregationKind="AGGREGATION">
+            <ownedMinCard xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="b9b1f071-3b27-4360-aca3-3eeeb561d3ef" value="1"/>
+            <ownedMaxCard xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="a65cec28-95be-4d3f-be47-c6c9cf5d66d3" value="1"/>
+          </ownedFeatures>
+        </ownedClasses>
+        <ownedClasses xsi:type="org.polarsys.capella.core.data.information:Class"
+            id="0093ffdd-ab4d-4c87-971d-0c2fc1a0b094" name="One"/>
+        <ownedClasses xsi:type="org.polarsys.capella.core.data.information:Class"
+            id="1dccccde-6ab1-47ac-8ee8-a3033a49a9e5" name="Two">
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.information:Property"
+              id="7ded1791-1b15-4cbc-9e2a-a711a32c9de2" name="three" abstractType="#322dc599-ea72-49e9-8e37-fe5226e41f19"
+              aggregationKind="COMPOSITION">
+            <ownedMinCard xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="8d1497f7-05b6-4aff-aed7-8c90af17f1de" value="1"/>
+            <ownedMaxCard xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="b8d7c19f-0f4a-47a7-936a-9d392abc7e83" value="1"/>
+          </ownedFeatures>
+        </ownedClasses>
+        <ownedClasses xsi:type="org.polarsys.capella.core.data.information:Class"
+            id="322dc599-ea72-49e9-8e37-fe5226e41f19" name="Three"/>
       </ownedDataPkg>
       <ownedRolePkg xsi:type="org.polarsys.capella.core.data.oa:RolePkg" id="bb3da84b-3be8-4d66-bb9d-38a4a485d149"
           name="Roles">
@@ -3093,7 +3163,7 @@ The predator is far away</bodies>
           <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="e721269a-87a2-4ae9-aa94-0f5376ef3461"
               name="MiddleStack" abstractType="#74af6883-25a0-446a-80f3-656f8a490b11"/>
           <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="92df1186-3cde-4e9e-9d6b-6609d006f36d"
-              name="Middle" abstractType="#16b4fcc5-548d-4721-b62a-d3d5b1c1d2eb"/>
+              name="Hierarchy" abstractType="#16b4fcc5-548d-4721-b62a-d3d5b1c1d2eb"/>
           <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="8186a7ec-045a-433a-bece-672b767775fe"
               name="Left 1" abstractType="#1c416771-64bc-4d0c-99eb-296ce27d0a35"/>
           <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="1a9e3f71-bf4d-442b-a3f3-9a97076f8390"

--- a/tests/test_class_tree_diagrams.py
+++ b/tests/test_class_tree_diagrams.py
@@ -18,11 +18,22 @@ def test_class_tree_diagram_gets_rendered_successfully(
     assert diag.render(fmt)
 
 
+@pytest.mark.parametrize("edgeRouting", ["SPLINE", "ORTHOGONAL", "POLYLINE"])
+@pytest.mark.parametrize("direction", ["DOWN", "RIGHT"])
+@pytest.mark.parametrize("partitioning", [True, False])
 def test_class_tree_diagram_renders_with_additional_params(
     model: capellambse.MelodyModel,
+    edgeRouting: str,
+    direction: str,
+    partitioning: bool,
 ) -> None:
     obj = model.by_uuid(CLASS_UUID)
 
     diag = obj.class_tree_diagram
 
-    assert diag.render("svgdiagram", edgeRouting="POLYLINE", direction="RIGHT")
+    assert diag.render(
+        "svgdiagram",
+        edgeRouting=edgeRouting,
+        direction=direction,
+        partitioning=partitioning,
+    )

--- a/tests/test_class_tree_diagrams.py
+++ b/tests/test_class_tree_diagrams.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import capellambse
+import pytest
+
+CLASS_UUID = "b7c7f442-377f-492c-90bf-331e66988bda"
+
+
+@pytest.mark.parametrize("fmt", ["svgdiagram", "svg", None])
+def test_class_tree_diagram_gets_rendered_successfully(
+    model: capellambse.MelodyModel, fmt: str
+) -> None:
+    obj = model.by_uuid(CLASS_UUID)
+
+    diag = obj.class_tree_diagram
+
+    assert diag.render(fmt)
+
+
+def test_class_tree_diagram_renders_with_additional_params(
+    model: capellambse.MelodyModel,
+) -> None:
+    obj = model.by_uuid(CLASS_UUID)
+
+    diag = obj.class_tree_diagram
+
+    assert diag.render("svgdiagram", edgeRouting="POLYLINE", direction="RIGHT")


### PR DESCRIPTION
![image](https://github.com/DSD-DBS/capellambse-context-diagrams/assets/50786483/70bb13a2-a553-477a-9a37-9f9f4242a8a3)

This PR adds a new type of diagram called Class Tree. The collection of classes is done via the `properties` attribute. Also complete control over the layouting algorithm, edge-routingstyle, direction and if partitioning should be enabled was implemented. It can be controlled via the rendering parameters.

This PR requires [capellambse #345](https://github.com/DSD-DBS/py-capellambse/pull/345).
It should be merged when the new feature is documented appropriately.