### PR TITLE
chore: Rename organisation name in license header and license files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+# SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: CC0-1.0
 
 # “.gitattributes Best Practices - Muhammad Rehan Saeed” {{{

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+# SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: CC0-1.0
 
 *       @ewuerger @vik378

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+# SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: Apache-2.0
 
 name: Build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+# SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: Apache-2.0
 
 name: Docs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+# SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: Apache-2.0
 
 name: Lint

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+# SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: CC0-1.0
 
 # Templates from <https://github.com/github/gitignore>

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+# SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: CC0-1.0
 
 exclude: '^(versioneer\.py|.*/_version\.py)$'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <!--
- ~ SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+ ~ SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 
@@ -110,7 +110,7 @@ Example:
 > Integration test for capability context diagrams seen in `tests/test_capability_diagrams.py`:
 >
 > ```python
-> # SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+> # SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 > # SPDX-License-Identifier: Apache-2.0
 >
 > import capellambse

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
- ~ SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+ ~ SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 
@@ -35,7 +35,7 @@ Special thanks goes to the developers and maintainers of [Eclipse Layout Kernelâ
 
 Copyright and license information added and maintained via the reuse tool from [Reuse Software](https://reuse.software/).
 
-***Copyright 2022 DB Netz AG, own contributions licensed under Apache 2.0 (see full text in [LICENSES/Apache-2.0](https://github.com/DSD-DBS/capellambse-context-diagrams/blob/master/LICENSES/Apache-2.0.txt))***
+***Copyright 2022 DB InfraGo AG, own contributions licensed under Apache 2.0 (see full text in [LICENSES/Apache-2.0](https://github.com/DSD-DBS/capellambse-context-diagrams/blob/master/LICENSES/Apache-2.0.txt))***
 
 ***Copyright (c) 2021 Kiel University and others, ELK/Sprotty contributions ([elkgraph-json.js](https://github.com/DSD-DBS/capellambse-context-diagrams/blob/master/capellambse_context_diagrams/elkgraph-json.js) & [elkgraph-to-sprotty.js](https://github.com/DSD-DBS/capellambse-context-diagrams/blob/master/capellambse_context_diagrams/elkgraph-to-sprotty.js)) licensed under EPL-2.0***
 

--- a/capellambse_context_diagrams/__init__.py
+++ b/capellambse_context_diagrams/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+# SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: Apache-2.0
 
 """The Context Diagrams model extension.

--- a/capellambse_context_diagrams/_elkjs.py
+++ b/capellambse_context_diagrams/_elkjs.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+# SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/capellambse_context_diagrams/collectors/__init__.py
+++ b/capellambse_context_diagrams/collectors/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+# SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/capellambse_context_diagrams/collectors/default.py
+++ b/capellambse_context_diagrams/collectors/default.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+# SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: Apache-2.0
 """
 Collection of [`ELKInputData`][capellambse_context_diagrams._elkjs.ELKInputData]

--- a/capellambse_context_diagrams/collectors/exchanges.py
+++ b/capellambse_context_diagrams/collectors/exchanges.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+# SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations

--- a/capellambse_context_diagrams/collectors/generic.py
+++ b/capellambse_context_diagrams/collectors/generic.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+# SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: Apache-2.0
 """
 Functionality for collection of model data from an instance of [`MelodyModel`][capellambse.model.MelodyModel]

--- a/capellambse_context_diagrams/collectors/makers.py
+++ b/capellambse_context_diagrams/collectors/makers.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+# SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations

--- a/capellambse_context_diagrams/collectors/portless.py
+++ b/capellambse_context_diagrams/collectors/portless.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+# SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/capellambse_context_diagrams/collectors/tree_view.py
+++ b/capellambse_context_diagrams/collectors/tree_view.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+# SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: Apache-2.0
 """This submodule defines the collector for the Class-Tree diagram."""
 from __future__ import annotations

--- a/capellambse_context_diagrams/context.py
+++ b/capellambse_context_diagrams/context.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+# SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: Apache-2.0
 """
 Definitions of Custom Accessor- and Diagram-Classtypes based on

--- a/capellambse_context_diagrams/elk.js
+++ b/capellambse_context_diagrams/elk.js
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+// SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 // SPDX-License-Identifier: Apache-2.0
 
 const elkgraphsprotty = require("./elkgraph-to-sprotty");

--- a/capellambse_context_diagrams/filters.py
+++ b/capellambse_context_diagrams/filters.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+# SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: Apache-2.0
 """Functions and registry for filter functionality."""
 from __future__ import annotations

--- a/capellambse_context_diagrams/serializers.py
+++ b/capellambse_context_diagrams/serializers.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+# SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: Apache-2.0
 
 """This submodule provides a serializer that transforms data from an ELK-

--- a/capellambse_context_diagrams/styling.py
+++ b/capellambse_context_diagrams/styling.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+# SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: Apache-2.0
 """Functions for style overrides of diagram elements."""
 from __future__ import annotations

--- a/docs/assets/images/Context of Left.svg
+++ b/docs/assets/images/Context of Left.svg
@@ -1,5 +1,5 @@
 <!--
- ~ SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+ ~ SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 

--- a/docs/assets/images/Interface Context of Left to right.svg
+++ b/docs/assets/images/Interface Context of Left to right.svg
@@ -1,5 +1,5 @@
 <!--
- ~ SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+ ~ SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 

--- a/docs/assets/images/favicon.ico.license
+++ b/docs/assets/images/favicon.ico.license
@@ -1,2 +1,2 @@
-SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 SPDX-License-Identifier: Apache-2.0

--- a/docs/assets/images/favicon.png.license
+++ b/docs/assets/images/favicon.png.license
@@ -1,2 +1,2 @@
-SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 SPDX-License-Identifier: Apache-2.0

--- a/docs/credits.md
+++ b/docs/credits.md
@@ -5,7 +5,7 @@ hide:
 ---
 
 <!--
- ~ SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+ ~ SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 

--- a/docs/css/base.css
+++ b/docs/css/base.css
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+ * SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/docs/extras/filters.md
+++ b/docs/extras/filters.md
@@ -1,5 +1,5 @@
 <!--
- ~ SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+ ~ SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 

--- a/docs/extras/styling.md
+++ b/docs/extras/styling.md
@@ -1,5 +1,5 @@
 <!--
- ~ SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+ ~ SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 

--- a/docs/gen_images.py
+++ b/docs/gen_images.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+# SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations

--- a/docs/gen_ref_pages.py
+++ b/docs/gen_ref_pages.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+# SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: Apache-2.0
 
 """Generate the code reference pages."""

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 <!--
- ~ SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+ ~ SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 

--- a/docs/license.md
+++ b/docs/license.md
@@ -1,5 +1,5 @@
 <!--
- ~ SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+ ~ SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,5 +1,5 @@
 <!--
- ~ SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+ ~ SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 

--- a/docs/tree_view.md
+++ b/docs/tree_view.md
@@ -1,5 +1,5 @@
 <!--
- ~ SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+ ~ SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 

--- a/license_header.txt
+++ b/license_header.txt
@@ -1,2 +1,2 @@
-SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 SPDX-License-Identifier: Apache-2.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+# SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: Apache-2.0
 
 site_name: Context diagrams for py-capellambse
@@ -102,7 +102,7 @@ extra:
     - icon: fontawesome/brands/github
       link: https://dsd-dbs.github.io/capellambse-context-diagrams/
     - icon: custom/db
-      name: DB Netz AG - SET
+      name: DB InfraGo AG - SET
       link: https://github.com/DSD-DBS
 
-copyright: Copyright &copy; 2022 DB Netz AG
+copyright: Copyright &copy; 2022 DB InfraGo AG

--- a/overrides/.icons/custom/db.svg
+++ b/overrides/.icons/custom/db.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
- ~ SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+ ~ SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+# SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: Apache-2.0
 
 [build-system]
@@ -14,7 +14,7 @@ readme = "README.md"
 requires-python = ">=3.9"
 license = { file = "LICENSES/Apache-2.0.txt" }
 authors = [
-  { name = "DB Netz AG" },
+  { name = "DB InfraGo AG" },
 ]
 keywords = ["capella", "mbse", "context", "diagram", "automatic diagrams"]
 classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+# SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: Apache-2.0
 
 import setuptools

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+# SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: Apache-2.0
 
 """Global fixtures for pytest"""

--- a/tests/data/.project.license
+++ b/tests/data/.project.license
@@ -1,2 +1,2 @@
-SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 SPDX-License-Identifier: Apache-2.0

--- a/tests/data/ContextDiagram.afm.license
+++ b/tests/data/ContextDiagram.afm.license
@@ -1,2 +1,2 @@
-SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 SPDX-License-Identifier: Apache-2.0

--- a/tests/data/ContextDiagram.aird.license
+++ b/tests/data/ContextDiagram.aird.license
@@ -1,2 +1,2 @@
-SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 SPDX-License-Identifier: Apache-2.0

--- a/tests/data/ContextDiagram.capella.license
+++ b/tests/data/ContextDiagram.capella.license
@@ -1,2 +1,2 @@
-SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 SPDX-License-Identifier: Apache-2.0

--- a/tests/test_capability_diagrams.py
+++ b/tests/test_capability_diagrams.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+# SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: Apache-2.0
 
 import capellambse

--- a/tests/test_context_diagrams.py
+++ b/tests/test_context_diagrams.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+# SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: Apache-2.0
 
 import capellambse

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+# SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations

--- a/tests/test_interface_diagrams.py
+++ b/tests/test_interface_diagrams.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+# SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: Apache-2.0
 
 import capellambse

--- a/tests/test_tree_views.py
+++ b/tests/test_tree_views.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
+# SPDX-FileCopyrightText: 2022 Copyright DB InfraGo AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: Apache-2.0
 
 import capellambse


### PR DESCRIPTION
`DB Netz AG` > `DB InfraGo AG`