### PR TITLE
feat(realization-view): Add `layer_sizing` render parameter

### DIFF
--- a/docs/realization_view.md
+++ b/docs/realization_view.md
@@ -32,6 +32,7 @@ implement currently. The diagram elements are collected from the
         depth=3, # 1-3
         search_direction="ALL", # BELOW; ABOVE and ALL
         show_owners=True,
+        layer_sizing="UNION", # UNION; WIDTH and HEIGHT
     ).save_drawing(pretty=True)
     ```
     <figure markdown>
@@ -51,6 +52,7 @@ implement currently. The diagram elements are collected from the
         depth=3,
         search_direction="ALL",
         show_owners=True,
+        layer_sizing="UNION",
     ).save_drawing(pretty=True)
     ```
     <figure markdown>
@@ -59,8 +61,9 @@ implement currently. The diagram elements are collected from the
     </figure>
 
 Additional rendering parameters enable showing owning functions or components,
-as well as the depth of traversion (i.e. `1`-`3`). They are put to display the
-maximum amount of diagram elements per default.
+as well as the depth of traversion (i.e. `1`-`3`) and control on sizing of the
+layer boxes. They are put to display the maximum amount of diagram elements per
+default.
 
 ??? bug "Alignment of diagram elements"
 

--- a/tests/test_realization_views.py
+++ b/tests/test_realization_views.py
@@ -27,11 +27,13 @@ def test_tree_view_gets_rendered_successfully(
 @pytest.mark.parametrize("depth", list(range(1, 4)))
 @pytest.mark.parametrize("search_direction", ["ABOVE", "BELOW"])
 @pytest.mark.parametrize("show_owners", [True, False])
+@pytest.mark.parametrize("layer_sizing", ["UNION", "WIDTH", "HEIGHT"])
 def test_tree_view_renders_with_additional_params(
     model: capellambse.MelodyModel,
     depth: int,
     search_direction: str,
     show_owners: bool,
+    layer_sizing: str,
     uuid: str,
 ) -> None:
     obj = model.by_uuid(uuid)
@@ -43,4 +45,5 @@ def test_tree_view_renders_with_additional_params(
         depth=depth,
         search_direction=search_direction,
         show_owners=show_owners,
+        layer_sizing=layer_sizing,
     )


### PR DESCRIPTION
# Layer sizing
## HEIGHT
![Realization view of advise Harry-HEIGHT](https://github.com/DSD-DBS/capellambse-context-diagrams/assets/50786483/5fe724d3-fca5-4779-afe2-7bcb218ef3be)
![Realization view of Physical System-HEIGHT](https://github.com/DSD-DBS/capellambse-context-diagrams/assets/50786483/349b542a-c771-4d6d-8358-12a0ffa880da)

## WIDTH
![Realization view of advise Harry-WIDTH](https://github.com/DSD-DBS/capellambse-context-diagrams/assets/50786483/16933521-b467-4f5e-8aa7-fe5c5e06d245)
![Realization view of Physical System-WIDTH](https://github.com/DSD-DBS/capellambse-context-diagrams/assets/50786483/3e953617-bac8-4907-a22d-8a6107771f76)

## UNION
![Realization view of advise Harry-UNION](https://github.com/DSD-DBS/capellambse-context-diagrams/assets/50786483/5731b0de-e15e-402e-9a25-9bd1e659e655)
![Realization view of Physical System-UNION](https://github.com/DSD-DBS/capellambse-context-diagrams/assets/50786483/c45e0c21-7832-45d7-863f-7b67335d32a1)

