### PR TITLE
Fix context diagrams

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,14 +143,14 @@ Example:
 >
 > Documentation can look like this `docs/index.md`:
 > ```markdown
-> - ??? example "🔥Brand-new🔥 [`ctx.Mission`][capellambse.model.layers.ctx.Mission] (MCB) 🔥Brand-new🔥"
+> - ??? example "[`ctx.Mission`][capellambse.model.layers.ctx.Mission] (MCB)"
 >
 >         ``` py
 >         import capellambse
 >
 >         model = capellambse.MelodyModel("tests/data/ContextDiagram.aird")
 >         diag = model.by_uuid("5bf3f1e3-0f5e-4fec-81d5-c113d3a1b3a6").context_diagram
->         diag.render("svgdiagram").save_drawing(pretty=True)
+>         diag.render("svgdiagram").save(pretty=True)
 >         ```
 >         <figure markdown>
 >             <img src="assets/images/Context of Top secret.svg" width="1000000">

--- a/capellambse_context_diagrams/collectors/default.py
+++ b/capellambse_context_diagrams/collectors/default.py
@@ -50,7 +50,7 @@ def collector(
         "output": -makers.NEIGHBOR_VMARGIN,
     }
     global_boxes = {centerbox["id"]: centerbox}
-    child_boxes = list[_elkjs.ELKInputChild]()
+    child_boxes: list[_elkjs.ELKInputChild] = []
     for i, local_ports, side in port_context_collector(ex_datas, ports):
         _, label_height = helpers.get_text_extent(i.name)
         height = max(
@@ -66,7 +66,9 @@ def collector(
             )
             box["height"] += height
         else:
-            box = makers.make_box(i, height=height)
+            box = makers.make_box(
+                i, height=height, no_symbol=diagram.display_symbols_as_boxes
+            )
             box["ports"] = [makers.make_port(j.uuid) for j in local_ports]
             if i.parent.uuid == centerbox["id"]:
                 child_boxes.append(box)

--- a/capellambse_context_diagrams/collectors/realization_view.py
+++ b/capellambse_context_diagrams/collectors/realization_view.py
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: 2022 Copyright DB InfraGO AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: Apache-2.0
 
-# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
-# SPDX-License-Identifier: Apache-2.0
 """This submodule defines the collector for the RealizationView diagram."""
 from __future__ import annotations
 

--- a/capellambse_context_diagrams/context.py
+++ b/capellambse_context_diagrams/context.py
@@ -212,7 +212,7 @@ class ContextDiagram(diagram.AbstractDiagram):
         obj: common.GenericElement,
         *,
         render_styles: dict[str, styling.Styler] | None = None,
-        display_symbols_as_boxes: bool = False,
+        display_symbols_as_boxes: bool = True,
         include_inner_objects: bool = False,
         slim_center_box: bool = True,
     ) -> None:

--- a/docs/extras/filters.md
+++ b/docs/extras/filters.md
@@ -26,7 +26,7 @@ Currently the supported filters are:
     diag = obj.context_diagram
     assert filters.EX_ITEMS == "show.exchange.items.filter"
     diag.filters.add(filters.EX_ITEMS)
-    diag.render("svgdiagram").save_drawing(pretty=True)
+    diag.render("svgdiagram").save(pretty=True)
     ```
     <figure markdown>
         <img src="../../assets/images/Context of Lost ex.svg" width="1000000">
@@ -43,7 +43,7 @@ Currently the supported filters are:
     diag = obj.context_diagram
     assert filters.FEX_EX_ITEMS == "show.functional.exchanges.exchange.items.filter"
     filters.filters = {filters.FEX_EX_ITEMS}
-    diag.render("svgdiagram").save_drawing(pretty=True)
+    diag.render("svgdiagram").save(pretty=True)
     ```
     <figure markdown>
         <img src="../../assets/images/Context of Lost fex and ex.svg" width="1000000">
@@ -62,7 +62,7 @@ Currently the supported filters are:
     diag = obj.context_diagram
     assert filters.FEX_OR_EX_ITEMS == "capellambse_context_diagrams-show.functional.exchanges.or.exchange.items.filter"
     filters.filters.add(filters.FEX_OR_EX_ITEMS)
-    diag.render("svgdiagram").save_drawing(pretty=True)
+    diag.render("svgdiagram").save(pretty=True)
     ```
     <figure markdown>
         <img src="../../assets/images/Context of Lost fex or ex.svg" width="1000000">

--- a/docs/extras/styling.md
+++ b/docs/extras/styling.md
@@ -22,7 +22,7 @@ Capella. These appear to be blue.
 
     model = capellambse.MelodyModel("tests/data/ContextDiagram.aird")
     diag = model.by_uuid("957c5799-1d4a-4ac0-b5de-33a65bf1519c").context_diagram
-    diag.render("svgdiagram").save_drawing(pretty=True)
+    diag.render("svgdiagram").save(pretty=True)
     ```
     produces
     <figure markdown>
@@ -46,8 +46,8 @@ icon beside the box-label. Per default this attribute is set to `True`.
     from capellambse import aird
 
     diag = model.by_uuid("da08ddb6-92ba-4c3b-956a-017424dbfe85").context_diagram
-    diag.display_symbols_as_boxes = True
-    diag.render("svgdiagram").save_drawing(pretty=True)
+    diag.display_symbols_as_boxes = True # per default
+    diag.render("svgdiagram").save(pretty=True)
     ```
     produces
     <figure markdown>
@@ -61,8 +61,8 @@ icon beside the box-label. Per default this attribute is set to `True`.
     from capellambse import aird
 
     diag = model.by_uuid("9390b7d5-598a-42db-bef8-23677e45ba06").context_diagram
-    diag.display_symbols_as_boxes = True
-    diag.render("svgdiagram").save_drawing(pretty=True)
+    diag.display_symbols_as_boxes = True # per default
+    diag.render("svgdiagram").save(pretty=True)
     ```
     produces
     <figure markdown>
@@ -81,7 +81,7 @@ The `no_edgelabels` render parameter prevents edge labels from being displayed.
 
     model = capellambse.MelodyModel("tests/data/ContextDiagram.aird")
     diag = model.by_uuid("957c5799-1d4a-4ac0-b5de-33a65bf1519c").context_diagram
-    diag.render("svgdiagram", no_edgelabels=True).save_drawing(pretty=True)
+    diag.render("svgdiagram", no_edgelabels=True).save(pretty=True)
     ```
     <figure markdown>
         <img src="../../assets/images/Context of educate Wizards no_edgelabels.svg" width="1000000">
@@ -101,7 +101,7 @@ You can switch to py-capellambse default styling by overriding the
 
     diag = model.by_uuid("957c5799-1d4a-4ac0-b5de-33a65bf1519c").context_diagram
     diag.render_styles = {}
-    diag.render("svgdiagram").save_drawing(pretty=True)
+    diag.render("svgdiagram").save(pretty=True)
     ```
     produces
     <figure markdown>
@@ -126,7 +126,7 @@ Style your diagram elements ([ElkChildType][capellambse_context_diagrams.seriali
         styling.BLUE_ACTOR_FNCS,
         junction=lambda obj, serializer: {"stroke": aird.RGB(220, 20, 60)},
     )
-    diag.render("svgdiagram").save_drawing(pretty=True)
+    diag.render("svgdiagram").save(pretty=True)
     ```
     produces
     <figure markdown>

--- a/docs/extras/styling.md
+++ b/docs/extras/styling.md
@@ -35,10 +35,10 @@ py-capellambse.
 
 # No symbol rendering
 
-There are some ModelObjects that are displayed as symbols in a diagram
-(e.g. Capabilities or Missions). The `.display_symbols_as_boxes` attribute
-gives you the control to render these as boxes such that the symbol is
-displayed as an icon beside the box-label.
+There are some ModelObjects that are displayed as symbols in a diagram (e.g.
+Capabilities or Missions). The `.display_symbols_as_boxes` attribute gives you
+the control to render these as boxes such that the symbol is displayed as an
+icon beside the box-label. Per default this attribute is set to `True`.
 
 ??? example "Box-only style for Context diagram of Middle OperationalCapability [OCB]"
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ Available via `.context_diagram` on a [`ModelObject`][capellambse.model.common.e
 
         model = capellambse.MelodyModel("tests/data/ContextDiagram.aird")
         diag = model.by_uuid("e37510b9-3166-4f80-a919-dfaac9b696c7").context_diagram
-        diag.render("svgdiagram").save_drawing(pretty=True)
+        diag.render("svgdiagram").save(pretty=True)
         ```
         <figure markdown>
             <img src="assets/images/Context of Environment.svg" width="1000000">
@@ -55,7 +55,7 @@ Available via `.context_diagram` on a [`ModelObject`][capellambse.model.common.e
 
         model = capellambse.MelodyModel("tests/data/ContextDiagram.aird")
         diag = model.by_uuid("8bcb11e6-443b-4b92-bec2-ff1d87a224e7").context_diagram
-        diag.render("svgdiagram").save_drawing(pretty=True)
+        diag.render("svgdiagram").save(pretty=True)
         ```
         <figure markdown>
             <img src="assets/images/Context of Eat.svg" width="1000000">
@@ -69,7 +69,7 @@ Available via `.context_diagram` on a [`ModelObject`][capellambse.model.common.e
 
         model = capellambse.MelodyModel("tests/data/ContextDiagram.aird")
         diag = model.by_uuid("da08ddb6-92ba-4c3b-956a-017424dbfe85").context_diagram
-        diag.render("svgdiagram").save_drawing(pretty=True)
+        diag.render("svgdiagram").save(pretty=True)
         ```
         <figure markdown>
             <img src="assets/images/Context of Middle.svg" width="1000000">
@@ -83,7 +83,7 @@ Available via `.context_diagram` on a [`ModelObject`][capellambse.model.common.e
 
         model = capellambse.MelodyModel("tests/data/ContextDiagram.aird")
         diag = model.by_uuid("5bf3f1e3-0f5e-4fec-81d5-c113d3a1b3a6").context_diagram
-        diag.render("svgdiagram").save_drawing(pretty=True)
+        diag.render("svgdiagram").save(pretty=True)
         ```
         <figure markdown>
             <img src="assets/images/Context of Top secret.svg" width="1000000">
@@ -97,7 +97,7 @@ Available via `.context_diagram` on a [`ModelObject`][capellambse.model.common.e
 
         model = capellambse.MelodyModel("tests/data/ContextDiagram.aird")
         diag = model.by_uuid("9390b7d5-598a-42db-bef8-23677e45ba06").context_diagram
-        diag.render("svgdiagram").save_drawing(pretty=True)
+        diag.render("svgdiagram").save(pretty=True)
         ```
         <figure markdown>
             <img src="assets/images/Context of Capability.svg" width="1000000">
@@ -113,7 +113,7 @@ Available via `.context_diagram` on a [`ModelObject`][capellambse.model.common.e
 
         model = capellambse.MelodyModel("tests/data/ContextDiagram.aird")
         diag = model.by_uuid("a5642060-c9cc-4d49-af09-defaa3024bae").context_diagram
-        diag.render("svgdiagram").save_drawing(pretty=True)
+        diag.render("svgdiagram").save(pretty=True)
         ```
         <figure markdown>
             <img src="assets/images/Context of Lost.svg" width="1000000">
@@ -127,7 +127,7 @@ Available via `.context_diagram` on a [`ModelObject`][capellambse.model.common.e
 
         model = capellambse.MelodyModel("tests/data/ContextDiagram.aird")
         diag = model.by_uuid("f632888e-51bc-4c9f-8e81-73e9404de784").context_diagram
-        diag.render("svgdiagram").save_drawing(pretty=True)
+        diag.render("svgdiagram").save(pretty=True)
         ```
         <figure markdown>
             <img src="assets/images/Context of Left.svg" width="1000000">
@@ -141,7 +141,7 @@ Available via `.context_diagram` on a [`ModelObject`][capellambse.model.common.e
 
         model = capellambse.MelodyModel("tests/data/ContextDiagram.aird")
         diag = model.by_uuid("957c5799-1d4a-4ac0-b5de-33a65bf1519c").context_diagram
-        diag.render("svgdiagram").save_drawing(pretty=True)
+        diag.render("svgdiagram").save(pretty=True)
         ```
         <figure markdown>
             <img src="assets/images/Context of educate Wizards.svg" width="1000000">
@@ -167,7 +167,7 @@ Hierarchy is identified and supported:
     model = capellambse.MelodyModel("tests/data/ContextDiagram.aird")
     obj = model.by_uuid("16b4fcc5-548d-4721-b62a-d3d5b1c1d2eb")
     diagram = obj.context_diagram.render("svgdiagram", include_inner_objects=True)
-    diagram.save_drawing(pretty=True)
+    diagram.save(pretty=True)
     ```
     <figure markdown>
         <img src="assets/images/Context of Hierarchy.svg" width="1000000">
@@ -185,7 +185,7 @@ The data is collected by [get_elkdata_for_exchanges][capellambse_context_diagram
 
     model = capellambse.MelodyModel("tests/data/ContextDiagram.aird")
     diag = model.by_uuid("3ef23099-ce9a-4f7d-812f-935f47e7938d").context_diagram
-    diag.render("svgdiagram").save_drawing(pretty=True)
+    diag.render("svgdiagram").save(pretty=True)
     ```
     <figure markdown>
         <img src="assets/images/Interface Context of Left to right.svg" width="1000000">

--- a/docs/realization_view.md
+++ b/docs/realization_view.md
@@ -3,12 +3,7 @@
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 
-<!--
- ~ SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
- ~ SPDX-License-Identifier: Apache-2.0
- -->
-
-# Tree View Diagram
+# 🔥Brand-new🔥 Tree View Diagram 🔥Brand-new🔥
 
 With release
 [`v0.5.42`](https://github.com/DSD-DBS/py-capellambse/releases/tag/v0.5.42) of

--- a/docs/realization_view.md
+++ b/docs/realization_view.md
@@ -28,7 +28,7 @@ implement currently. The diagram elements are collected from the
         search_direction="ALL", # BELOW; ABOVE and ALL
         show_owners=True,
         layer_sizing="UNION", # UNION; WIDTH and HEIGHT
-    ).save_drawing(pretty=True)
+    ).save(pretty=True)
     ```
     <figure markdown>
         <img src="../assets/images/Realization view of advise Harry.svg">
@@ -48,7 +48,7 @@ implement currently. The diagram elements are collected from the
         search_direction="ALL",
         show_owners=True,
         layer_sizing="UNION",
-    ).save_drawing(pretty=True)
+    ).save(pretty=True)
     ```
     <figure markdown>
         <img src="../assets/images/Realization view of Physical System.svg">

--- a/docs/tree_view.md
+++ b/docs/tree_view.md
@@ -17,7 +17,7 @@ parent class.
 
     model = capellambse.MelodyModel("tests/data/ContextDiagram.aird")
     diag = model.by_uuid("b7c7f442-377f-492c-90bf-331e66988bda").tree_view
-    diag.render("svgdiagram").save_drawing(pretty=True)
+    diag.render("svgdiagram").save(pretty=True)
     ```
     <figure markdown>
         <img src="../assets/images/Tree view of Root.svg">
@@ -68,7 +68,7 @@ before rendering:
         direction="Right",
         # partitioning=False,
         # edgeLabelsSide="ALWAYS_DOWN",
-    ).save_drawing(pretty=True)
+    ).save(pretty=True)
     ```
     <figure markdown>
         <img src="../assets/images/Tree view of Root-params.svg">

--- a/tests/test_realization_views.py
+++ b/tests/test_realization_views.py
@@ -1,9 +1,6 @@
 # SPDX-FileCopyrightText: 2022 Copyright DB InfraGO AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: Apache-2.0
 
-# SPDX-FileCopyrightText: 2022 Copyright DB Netz AG and the capellambse-context-diagrams contributors
-# SPDX-License-Identifier: Apache-2.0
-
 import capellambse
 import pytest
 


### PR DESCRIPTION
Render context diagrams with symbols with `display_symbols_as_boxes` per default.

**_Depends on [py-capellambse #372](https://github.com/DSD-DBS/py-capellambse/pull/372)._**