### PR TITLE
feat(context-diagrams): Add `display_parent_relation` feature

### DIFF
--- a/capellambse_context_diagrams/collectors/default.py
+++ b/capellambse_context_diagrams/collectors/default.py
@@ -60,14 +60,14 @@ def collector(
         "output": -makers.NEIGHBOR_VMARGIN,
     }
     child_boxes: list[_elkjs.ELKInputChild] = []
-    for i, local_ports, side in port_context_collector(ex_datas, ports):
-        _, label_height = helpers.get_text_extent(i.name)
+    for child, local_ports, side in port_context_collector(ex_datas, ports):
+        _, label_height = helpers.get_text_extent(child.name)
         height = max(
             label_height + 2 * makers.LABEL_VPAD,
             makers.PORT_PADDING
             + (makers.PORT_SIZE + makers.PORT_PADDING) * len(local_ports),
         )
-        if box := global_boxes.get(i.uuid):  # type: ignore[assignment]
+        if box := global_boxes.get(child.uuid):  # type: ignore[assignment]
             if box is centerbox:
                 continue
             box.setdefault("ports", []).extend(
@@ -76,23 +76,25 @@ def collector(
             box["height"] += height
         else:
             box = makers.make_box(
-                i, height=height, no_symbol=diagram.display_symbols_as_boxes
+                child,
+                height=height,
+                no_symbol=diagram.display_symbols_as_boxes,
             )
             box["ports"] = [makers.make_port(j.uuid) for j in local_ports]
-            if i.parent.uuid == centerbox["id"]:
+            if child.parent.uuid == centerbox["id"]:
                 child_boxes.append(box)
             else:
-                global_boxes[i.uuid] = box
+                global_boxes[child.uuid] = box
 
         if diagram.display_parent_relation:
-            if i == diagram.target.parent:
+            if child == diagram.target.parent:
                 _move_edge_to_local_edges(
                     box, connections, local_ports, diagram, data
                 )
-            elif i.parent == diagram.target.parent:
-                parent_box = global_boxes[i.parent.uuid]
+            elif child.parent == diagram.target.parent:
+                parent_box = global_boxes[child.parent.uuid]
                 parent_box.setdefault("children", []).append(
-                    global_boxes.pop(i.uuid)
+                    global_boxes.pop(child.uuid)
                 )
                 _move_edge_to_local_edges(
                     parent_box, connections, local_ports, diagram, data

--- a/capellambse_context_diagrams/context.py
+++ b/capellambse_context_diagrams/context.py
@@ -231,6 +231,9 @@ class ContextDiagram(diagram.AbstractDiagram):
         avoids the object of interest to become one giant, oversized
         symbol in the middle of the diagram, and instead keeps the
         symbol small and only enlarges the surrounding box.
+    display_parent_relation
+        Display objects with a parent relationship to the object of
+        interest as the parent box.
     slim_center_box
         Minimal width for the center box, containing just the icon and
         the label. This is False if hierarchy was identified.
@@ -253,6 +256,7 @@ class ContextDiagram(diagram.AbstractDiagram):
         *,
         render_styles: dict[str, styling.Styler] | None = None,
         display_symbols_as_boxes: bool = False,
+        display_parent_relation: bool = False,
         include_inner_objects: bool = False,
         slim_center_box: bool = True,
     ) -> None:
@@ -264,6 +268,7 @@ class ContextDiagram(diagram.AbstractDiagram):
         self.serializer = serializers.DiagramSerializer(self)
         self.__filters: cabc.MutableSet[str] = self.FilterSet(self)
         self.display_symbols_as_boxes = display_symbols_as_boxes
+        self.display_parent_relation = display_parent_relation
         self.include_inner_objects = include_inner_objects
         self.slim_center_box = slim_center_box
 

--- a/capellambse_context_diagrams/serializers.py
+++ b/capellambse_context_diagrams/serializers.py
@@ -202,7 +202,7 @@ class DiagramSerializer:
                 pos += self.diagram[self._diagram.target.uuid].pos
 
             element = diagram.Circle(
-                pos,
+                ref + pos,
                 5,
                 uuid=child["id"],
                 styleclass=self.get_styleclass(uuid),

--- a/capellambse_context_diagrams/serializers.py
+++ b/capellambse_context_diagrams/serializers.py
@@ -106,7 +106,7 @@ class DiagramSerializer:
             class type that stores all previously named classes.
         """
         styleclass: str | None = self.get_styleclass(child["id"])
-        element: diagram.Box | diagram.Edge
+        element: diagram.Box | diagram.Edge | diagram.Circle
         if child["type"] in {"node", "port"}:
             assert parent is None or isinstance(parent, diagram.Box)
             has_symbol_cls = False


### PR DESCRIPTION
This moves the centerbox into its parent box if it is in the context. Also other boxes are moved into the parent box if the parent-child relation holds.

**_This PR depends on [py-capellambse #381](https://github.com/DSD-DBS/py-capellambse/pull/381)._**