### PR TITLE
Fix tree view

### DIFF
--- a/capellambse_context_diagrams/collectors/tree_view.py
+++ b/capellambse_context_diagrams/collectors/tree_view.py
@@ -128,7 +128,12 @@ def collector(
     _set_layout_options(data, params)
     processor = ClassProcessor(data, all_associations)
     processor._set_data_types_and_labels(data["children"][0], diagram.target)
-    for _, cls in get_all_classes(diagram.target):
+    for _, cls in get_all_classes(
+        diagram.target,
+        max_partition=params.get("depth"),
+        super=params.get("super", "ROOT"),
+        sub=params.get("sub", "ROOT"),
+    ):
         processor.process_class(cls, params)
 
     legend = makers.make_diagram(diagram)
@@ -140,7 +145,10 @@ def collector(
 def _set_layout_options(
     data: _elkjs.ELKInputData, params: dict[str, t.Any]
 ) -> None:
-    data["layoutOptions"] = {**DEFAULT_LAYOUT_OPTIONS, **params}
+    options = {
+        k: v for k, v in params.items() if k not in ("depth", "super", "sub")
+    }
+    data["layoutOptions"] = {**DEFAULT_LAYOUT_OPTIONS, **options}
     _set_partitioning(data["children"][0], 0, params)
 
 
@@ -163,75 +171,141 @@ class ClassInfo:
     primitive: bool = False
 
 
+@dataclasses.dataclass
+class _PropertyInfo:
+    """Builder dataclass for properties."""
+
+    source: information.Class
+    prop: information.Property
+    partition: int
+    classes: dict[str, ClassInfo] = dataclasses.field(default_factory=dict)
+    generalizes: information.Class | None = None
+    max_partition: int | None = None
+    super: t.Literal["ROOT"] | t.Literal["ALL"] = "ALL"
+    sub: t.Literal["ROOT"] | t.Literal["ALL"] = "ALL"
+
+
 def process_property(
-    source: information.Class,
-    prop: information.Property,
-    partition: int,
-    classes: dict[str, ClassInfo],
-    generalizes: information.Class | None = None,
-) -> bool:
+    property: _PropertyInfo,
+) -> None:
     """Process a single property for class information."""
+    prop = property.prop
     if not prop.type:
         logger.warning(
             "Property without abstract type found: %r", prop._short_repr_()
         )
-        return False
+        return
 
     if not prop.type.xtype.endswith("Class") or prop.type.is_primitive:
         logger.debug("Ignoring non-class property: %r", prop._short_repr_())
-        return False
+        return
 
-    edge_id = f"{source.uuid} {prop.uuid} {prop.type.uuid}"
-    if edge_id not in classes:
-        classes[edge_id] = _make_class_info(
-            source, prop, partition, generalizes=generalizes
+    if (
+        property.max_partition is not None
+        and property.partition > property.max_partition
+    ):
+        return
+
+    edge_id = f"{property.source.uuid} {prop.uuid} {prop.type.uuid}"
+    if edge_id not in property.classes:
+        property.classes[edge_id] = _make_class_info(
+            property.source,
+            prop,
+            property.partition,
+            generalizes=property.generalizes,
         )
-        classes.update(get_all_classes(prop.type, partition, classes))
-    return True
+        property.classes.update(
+            get_all_classes(
+                prop.type,
+                property.partition,
+                property.classes,
+                property.max_partition,
+                property.super,
+                property.sub,
+            )
+        )
 
 
 def get_all_classes(
     root: information.Class,
     partition: int = 0,
     classes: dict[str, ClassInfo] | None = None,
+    max_partition: int | None = None,
+    super: t.Literal["ROOT"] | t.Literal["ALL"] = "ALL",
+    sub: t.Literal["ROOT"] | t.Literal["ALL"] = "ALL",
 ) -> cabc.Iterator[tuple[str, ClassInfo]]:
     """Yield all classes of the class tree."""
     partition += 1
     classes = classes or {}
+    if max_partition is not None and partition > max_partition:
+        return
 
     for prop in root.owned_properties:
-        process_property(root, prop, partition, classes)
+        property = _PropertyInfo(
+            root, prop, partition, classes, None, max_partition, super, sub
+        )
+        process_property(property)
 
-    if root.super and not root.super.is_primitive:
-        processed_properties = [
-            process_property(
-                root.super, prop, partition, classes, generalizes=root
-            )
-            for prop in root.super.owned_properties
-        ]
+    if super == "ALL" or (super == "ROOT" and partition == 1):
+        if root.super and not root.super.is_primitive:
+            for prop in root.super.owned_properties:
+                process_property(
+                    _PropertyInfo(
+                        root.super,
+                        prop,
+                        partition + 1,
+                        classes,
+                        root,
+                        max_partition,
+                        super,
+                        sub,
+                    )
+                )
 
-        if not root.super.owned_properties or any(processed_properties):
-            if (edge_id := f"{root.uuid} {root.super.uuid}") not in classes:
+            edge_id = f"{root.uuid} {root.super.uuid}"
+            if edge_id not in classes:
                 classes[edge_id] = _make_class_info(
                     root.super, None, partition, generalizes=root
                 )
-                classes.update(get_all_classes(root.super, partition, classes))
+                classes.update(
+                    get_all_classes(
+                        root.super,
+                        partition,
+                        classes,
+                        max_partition,
+                        super,
+                        sub,
+                    )
+                )
 
-    for cls in root.sub:
-        if cls.is_primitive:
-            continue
+    if sub == "ALL" or (sub == "ROOT" and partition == 1):
+        for cls in root.sub:
+            if cls.is_primitive:
+                continue
 
-        processed_properties = [
-            process_property(root, prop, partition, classes, generalizes=cls)
-            for prop in cls.owned_properties
-        ]
+            for prop in cls.owned_properties:
+                process_property(
+                    _PropertyInfo(
+                        root,
+                        prop,
+                        partition,
+                        classes,
+                        cls,
+                        max_partition,
+                        super,
+                        sub,
+                    )
+                )
 
-        if not cls.owned_properties or not any(processed_properties):
             if (edge_id := f"{root.uuid} {cls.uuid}") not in classes:
                 classes[edge_id] = _make_class_info(
                     root, None, partition, generalizes=cls
                 )
-                classes.update(get_all_classes(cls, partition, classes))
+                classes.update(
+                    get_all_classes(
+                        cls, partition, classes, max_partition, super, sub
+                    )
+                )
 
     yield from classes.items()
 
@@ -296,7 +370,14 @@ def _get_all_non_edge_properties(
 
 
 def _get_property_text(prop: information.Property) -> str:
-    text = f"{prop.name}: {prop.type.name}"
+    text = prop.name
+    if prop.type is not None:
+        text = f"{prop.name}: {prop.type.name}"
+    else:
+        logger.warning(
+            "Property without abstract type found: %r", prop._short_repr_()
+        )
+
     if prop.min_card.value != "1" or prop.max_card.value != "1":
         text = f"[{prop.min_card.value}..{prop.max_card.value}] {text}"
     return text

--- a/capellambse_context_diagrams/collectors/tree_view.py
+++ b/capellambse_context_diagrams/collectors/tree_view.py
@@ -233,16 +233,6 @@ def get_all_classes(
                 )
                 classes.update(get_all_classes(cls, partition, classes))
 
-    for cls in root.sub:
-        if cls.is_primitive:
-            continue
-
-        edge_id = f"{root.uuid} {cls.uuid}"
-        if edge_id not in classes:
-            classes[edge_id] = _make_class_info(
-                root, prop, partition, generalizes=cls
-            )
-            classes.update(dict(get_all_classes(cls, partition, classes)))
     yield from classes.items()
 
 

--- a/capellambse_context_diagrams/collectors/tree_view.py
+++ b/capellambse_context_diagrams/collectors/tree_view.py
@@ -80,8 +80,8 @@ class ClassProcessor:
                 self.data["edges"].append(
                     {
                         "id": edge.uuid,
-                        "sources": [cls.generalizes.uuid],
-                        "targets": [cls.source.uuid],
+                        "sources": [cls.source.uuid],
+                        "targets": [cls.generalizes.uuid],
                     }
                 )
 
@@ -122,9 +122,9 @@ def collector(
     """Return the class tree data for ELK."""
     assert isinstance(diagram.target, information.Class)
     data = generic.collector(diagram, no_symbol=True)
-    all_associations: cabc.Iterable[information.Association] = (
-        diagram._model.search("Association")
-    )
+    all_associations: cabc.Iterable[
+        information.Association
+    ] = diagram._model.search("Association")
     _set_layout_options(data, params)
     processor = ClassProcessor(data, all_associations)
     processor._set_data_types_and_labels(data["children"][0], diagram.target)

--- a/capellambse_context_diagrams/collectors/tree_view.py
+++ b/capellambse_context_diagrams/collectors/tree_view.py
@@ -122,9 +122,9 @@ def collector(
     """Return the class tree data for ELK."""
     assert isinstance(diagram.target, information.Class)
     data = generic.collector(diagram, no_symbol=True)
-    all_associations: cabc.Iterable[
-        information.Association
-    ] = diagram._model.search("Association")
+    all_associations: cabc.Iterable[information.Association] = (
+        diagram._model.search("Association")
+    )
     _set_layout_options(data, params)
     processor = ClassProcessor(data, all_associations)
     processor._set_data_types_and_labels(data["children"][0], diagram.target)
@@ -233,6 +233,16 @@ def get_all_classes(
                 )
                 classes.update(get_all_classes(cls, partition, classes))
 
+    for cls in root.sub:
+        if cls.is_primitive:
+            continue
+
+        edge_id = f"{root.uuid} {cls.uuid}"
+        if edge_id not in classes:
+            classes[edge_id] = _make_class_info(
+                root, prop, partition, generalizes=cls
+            )
+            classes.update(dict(get_all_classes(cls, partition, classes)))
     yield from classes.items()
 
 

--- a/docs/tree_view.md
+++ b/docs/tree_view.md
@@ -52,6 +52,18 @@ classes is its own partition.
     - DIRECTION_UP
     - DIRECTION_DOWN
 
+Additionally the following render parameters are offered:
+
+1. depth - The depth of the computed tree. Defaults to `None` such that the
+whole tree is computed. `depth=1` means that only first level properties and
+generalizations are collected.
+2. super - Generalizations from the `super` attribute, can be set to
+    - ALL
+    - ROOT
+3. sub - Generalizations from the `sub` attribute, can be set to
+    - ALL
+    - ROOT
+
 Here is an example that shows how convenient these parameters can be passed
 before rendering:
 

--- a/tests/data/ContextDiagram.aird
+++ b/tests/data/ContextDiagram.aird
@@ -8,7 +8,7 @@
     </ownedViews>
     <ownedViews xmi:type="viewpoint:DView" uid="__FJxoKDzEeqf7Mw7EIo_Ew">
       <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']"/>
-      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_OmRFoGwfEe6iyfecRwAuGw" name="[CDB] Data" repPath="#_OmIiwGwfEe6iyfecRwAuGw" changeId="8733cf88-652d-4faf-8681-f70453d639a1">
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_OmRFoGwfEe6iyfecRwAuGw" name="[CDB] Data" repPath="#_OmIiwGwfEe6iyfecRwAuGw" changeId="cdf2291c-a8f6-4c5d-9964-66e0b9d583a4">
         <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']"/>
         <target xmi:type="org.polarsys.capella.core.data.information:DataPkg" href="ContextDiagram.capella#d12c04b6-392f-4761-be5a-e44c688823f6"/>
       </ownedRepresentationDescriptors>
@@ -8008,10 +8008,6 @@
               <styles xmi:type="notation:FontStyle" xmi:id="_eZmtAXPqEe6dn5jaT-bpNQ" fontName="Fira Code" fontHeight="8"/>
               <layoutConstraint xmi:type="notation:Location" xmi:id="_eZmtAnPqEe6dn5jaT-bpNQ"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_fG7tEHPqEe6dn5jaT-bpNQ" type="3010" element="_fGfBIHPqEe6dn5jaT-bpNQ">
-              <styles xmi:type="notation:FontStyle" xmi:id="_fG7tEXPqEe6dn5jaT-bpNQ" fontName="Fira Code" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_fG7tEnPqEe6dn5jaT-bpNQ"/>
-            </children>
             <children xmi:type="notation:Node" xmi:id="_fpfnkHPqEe6dn5jaT-bpNQ" type="3010" element="_fo-qMHPqEe6dn5jaT-bpNQ">
               <styles xmi:type="notation:FontStyle" xmi:id="_fpfnkXPqEe6dn5jaT-bpNQ" fontName="Fira Code" fontHeight="8"/>
               <layoutConstraint xmi:type="notation:Location" xmi:id="_fpfnknPqEe6dn5jaT-bpNQ"/>
@@ -8060,7 +8056,7 @@
             <styles xmi:type="notation:FilteringStyle" xmi:id="_E7DSk29WEe6Ky_42MorwEQ"/>
           </children>
           <styles xmi:type="notation:ShapeStyle" xmi:id="_E7A2UW9WEe6Ky_42MorwEQ" fontName="Fira Code" fontHeight="8"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E7A2Um9WEe6Ky_42MorwEQ" x="90" y="482" width="103" height="72"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E7A2Um9WEe6Ky_42MorwEQ" x="91" y="761" width="103" height="72"/>
         </children>
         <children xmi:type="notation:Node" xmi:id="_zrvX0G9eEe6Ky_42MorwEQ" type="2003" element="_zrJh8G9eEe6Ky_42MorwEQ">
           <children xmi:type="notation:Node" xmi:id="_zrvX029eEe6Ky_42MorwEQ" type="5007"/>
@@ -8077,7 +8073,7 @@
             <styles xmi:type="notation:FilteringStyle" xmi:id="_zrvX1m9eEe6Ky_42MorwEQ"/>
           </children>
           <styles xmi:type="notation:ShapeStyle" xmi:id="_zrvX0W9eEe6Ky_42MorwEQ" fontName="Fira Code" fontHeight="8"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zrvX0m9eEe6Ky_42MorwEQ" x="230" y="481" width="152" height="73"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zrvX0m9eEe6Ky_42MorwEQ" x="231" y="760" width="152" height="73"/>
         </children>
         <children xmi:type="notation:Node" xmi:id="_6buwcHPpEe6dn5jaT-bpNQ" type="2003" element="_6aCuZnPpEe6dn5jaT-bpNQ">
           <children xmi:type="notation:Node" xmi:id="_6bya0HPpEe6dn5jaT-bpNQ" type="5007"/>
@@ -8110,7 +8106,7 @@
             <styles xmi:type="notation:FilteringStyle" xmi:id="_6bzo8nPpEe6dn5jaT-bpNQ"/>
           </children>
           <styles xmi:type="notation:ShapeStyle" xmi:id="_6buwcXPpEe6dn5jaT-bpNQ" fontName="Fira Code" fontHeight="8"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6e5ZMHPpEe6dn5jaT-bpNQ" x="400" y="481" width="153" height="181"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6e5ZMHPpEe6dn5jaT-bpNQ" x="401" y="760" width="153" height="181"/>
         </children>
         <children xmi:type="notation:Node" xmi:id="_6un3QHPpEe6dn5jaT-bpNQ" type="2003" element="_6tz-9nPpEe6dn5jaT-bpNQ">
           <children xmi:type="notation:Node" xmi:id="_6uoeUHPpEe6dn5jaT-bpNQ" type="5007"/>
@@ -8127,7 +8123,7 @@
             <styles xmi:type="notation:FilteringStyle" xmi:id="_6uoeU3PpEe6dn5jaT-bpNQ"/>
           </children>
           <styles xmi:type="notation:ShapeStyle" xmi:id="_6un3QXPpEe6dn5jaT-bpNQ" fontName="Fira Code" fontHeight="8"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6wth8HPpEe6dn5jaT-bpNQ" x="570" y="481" width="152" height="73"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6wth8HPpEe6dn5jaT-bpNQ" x="571" y="760" width="152" height="73"/>
         </children>
         <children xmi:type="notation:Node" xmi:id="_6-YxkHPpEe6dn5jaT-bpNQ" type="2003" element="_695pZnPpEe6dn5jaT-bpNQ">
           <children xmi:type="notation:Node" xmi:id="_6-ZYoHPpEe6dn5jaT-bpNQ" type="5007"/>
@@ -8144,7 +8140,7 @@
             <styles xmi:type="notation:FilteringStyle" xmi:id="_6-ZYo3PpEe6dn5jaT-bpNQ"/>
           </children>
           <styles xmi:type="notation:ShapeStyle" xmi:id="_6-YxkXPpEe6dn5jaT-bpNQ" fontName="Fira Code" fontHeight="8"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6_7CoHPpEe6dn5jaT-bpNQ" x="740" y="481" width="152" height="73"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6_7CoHPpEe6dn5jaT-bpNQ" x="741" y="760" width="152" height="73"/>
         </children>
         <children xmi:type="notation:Node" xmi:id="_7JDwgHPpEe6dn5jaT-bpNQ" type="2003" element="_7IlPZnPpEe6dn5jaT-bpNQ">
           <children xmi:type="notation:Node" xmi:id="_7JEXkHPpEe6dn5jaT-bpNQ" type="5007"/>
@@ -8161,7 +8157,7 @@
             <styles xmi:type="notation:FilteringStyle" xmi:id="_7JEXk3PpEe6dn5jaT-bpNQ"/>
           </children>
           <styles xmi:type="notation:ShapeStyle" xmi:id="_7JDwgXPpEe6dn5jaT-bpNQ" fontName="Fira Code" fontHeight="8"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7KqTAHPpEe6dn5jaT-bpNQ" x="221" y="590" width="152" height="73"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7KqTAHPpEe6dn5jaT-bpNQ" x="222" y="869" width="152" height="73"/>
         </children>
         <children xmi:type="notation:Node" xmi:id="_7omzQHPpEe6dn5jaT-bpNQ" type="2003" element="_7oMjlnPpEe6dn5jaT-bpNQ">
           <children xmi:type="notation:Node" xmi:id="_7onaUHPpEe6dn5jaT-bpNQ" type="5007"/>
@@ -8178,7 +8174,7 @@
             <styles xmi:type="notation:FilteringStyle" xmi:id="_7onaU3PpEe6dn5jaT-bpNQ"/>
           </children>
           <styles xmi:type="notation:ShapeStyle" xmi:id="_7omzQXPpEe6dn5jaT-bpNQ" fontName="Fira Code" fontHeight="8"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7p-FMHPpEe6dn5jaT-bpNQ" x="570" y="579" width="152" height="73"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7p-FMHPpEe6dn5jaT-bpNQ" x="571" y="858" width="152" height="73"/>
         </children>
         <children xmi:type="notation:Node" xmi:id="_yX73UMwIEe6cROezh8CcIg" type="2003" element="_yXYdsMwIEe6cROezh8CcIg">
           <children xmi:type="notation:Node" xmi:id="_yX-6oMwIEe6cROezh8CcIg" type="5007"/>
@@ -8200,7 +8196,20 @@
             <styles xmi:type="notation:FilteringStyle" xmi:id="_d-9WlswJEe6cROezh8CcIg"/>
           </children>
           <styles xmi:type="notation:ShapeStyle" xmi:id="_d-9WkcwJEe6cROezh8CcIg" fontName="Fira Code" fontHeight="8"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_d-9WkswJEe6cROezh8CcIg" x="20" y="592"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_d-9WkswJEe6cROezh8CcIg" x="21" y="871"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_Or9nANGCEe6Qjsqma8S9Aw" type="2003" element="_OrJHoNGCEe6Qjsqma8S9Aw">
+          <children xmi:type="notation:Node" xmi:id="_Or_cMNGCEe6Qjsqma8S9Aw" type="5007"/>
+          <children xmi:type="notation:Node" xmi:id="_Or_cMdGCEe6Qjsqma8S9Aw" type="7004">
+            <children xmi:type="notation:Node" xmi:id="_mZS3oNGFEe6Qjsqma8S9Aw" type="3010" element="_mYwFENGFEe6Qjsqma8S9Aw">
+              <styles xmi:type="notation:FontStyle" xmi:id="_mZS3odGFEe6Qjsqma8S9Aw" fontName="Fira Code" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_mZS3otGFEe6Qjsqma8S9Aw"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_Or_cMtGCEe6Qjsqma8S9Aw"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_Or_cM9GCEe6Qjsqma8S9Aw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_Or9nAdGCEe6Qjsqma8S9Aw" fontName="Fira Code" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Or9nAtGCEe6Qjsqma8S9Aw" x="530" y="540" width="164" height="53"/>
         </children>
         <styles xmi:type="notation:DiagramStyle" xmi:id="_OmWlMmwfEe6iyfecRwAuGw"/>
         <edges xmi:type="notation:Edge" xmi:id="_4vzTMGwfEe6iyfecRwAuGw" type="4001" element="_4vKaAGwfEe6iyfecRwAuGw" source="_PLddYGwfEe6iyfecRwAuGw" target="_RGnigGwfEe6iyfecRwAuGw">
@@ -8283,6 +8292,22 @@
           <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8IlSAswIEe6cROezh8CcIg" id="(0.0,0.5128205128205128)"/>
           <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8IlSA8wIEe6cROezh8CcIg" id="(0.6896551724137931,0.022222222222222223)"/>
         </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_TMvDgNGCEe6Qjsqma8S9Aw" type="4001" element="_TMS-qNGCEe6Qjsqma8S9Aw" source="_UHt8AGwfEe6iyfecRwAuGw" target="_Or9nANGCEe6Qjsqma8S9Aw">
+          <children xmi:type="notation:Node" xmi:id="_TMvqkNGCEe6Qjsqma8S9Aw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TMvqkdGCEe6Qjsqma8S9Aw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_TMwRoNGCEe6Qjsqma8S9Aw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TMwRodGCEe6Qjsqma8S9Aw" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_TMwRotGCEe6Qjsqma8S9Aw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TMwRo9GCEe6Qjsqma8S9Aw" x="-1" y="19"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_TMvDgdGCEe6Qjsqma8S9Aw" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_TMvDgtGCEe6Qjsqma8S9Aw" fontName="Fira Code" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TMvDg9GCEe6Qjsqma8S9Aw" points="[0, 0, 0, -75]$[0, 75, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TMxfwNGCEe6Qjsqma8S9Aw" id="(0.5043103448275862,1.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TMxfwdGCEe6Qjsqma8S9Aw" id="(0.2897657213316893,0.0)"/>
+        </edges>
       </data>
     </ownedAnnotationEntries>
     <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_Om5XwGwfEe6iyfecRwAuGw" source="DANNOTATION_CUSTOMIZATION_KEY">
@@ -8338,15 +8363,7 @@
         </ownedStyle>
         <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@defaultLayer/@containerMappings[name='DT_Class']/@subNodeMappings[name='DT_Property']"/>
       </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_fGfBIHPqEe6dn5jaT-bpNQ" name=" another_one_one_one : EnumExample_4">
-        <target xmi:type="org.polarsys.capella.core.data.information:Property" href="ContextDiagram.capella#ebbf0505-eac3-4552-96f8-de2b06a93f1e"/>
-        <semanticElements xmi:type="org.polarsys.capella.core.data.information:Property" href="ContextDiagram.capella#ebbf0505-eac3-4552-96f8-de2b06a93f1e"/>
-        <ownedStyle xmi:type="diagram:Square" uid="_fGfBIXPqEe6dn5jaT-bpNQ" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1" borderColor="136,136,136">
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@defaultLayer/@containerMappings[name='DT_Class']/@subNodeMappings[name='DT_Property']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@defaultLayer/@containerMappings[name='DT_Class']/@subNodeMappings[name='DT_Property']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_fo-qMHPqEe6dn5jaT-bpNQ" name=" last_one : EnumExample_5">
+      <ownedElements xmi:type="diagram:DNodeListElement" uid="_fo-qMHPqEe6dn5jaT-bpNQ" name=" last_one : EnumExample_4">
         <target xmi:type="org.polarsys.capella.core.data.information:Property" href="ContextDiagram.capella#69509f7b-54a2-43ca-958b-ae03ac3d285c"/>
         <semanticElements xmi:type="org.polarsys.capella.core.data.information:Property" href="ContextDiagram.capella#69509f7b-54a2-43ca-958b-ae03ac3d285c"/>
         <ownedStyle xmi:type="diagram:Square" uid="_fo-qMXPqEe6dn5jaT-bpNQ" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1" borderColor="136,136,136">
@@ -8377,7 +8394,7 @@
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@defaultLayer/@containerMappings[name='DT_Class']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_UHJUQGwfEe6iyfecRwAuGw" name="Three" incomingEdges="_6YiyqGwfEe6iyfecRwAuGw _71iVEGwfEe6iyfecRwAuGw _8H4ucMwIEe6cROezh8CcIg">
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_UHJUQGwfEe6iyfecRwAuGw" name="Three" outgoingEdges="_TMS-qNGCEe6Qjsqma8S9Aw" incomingEdges="_6YiyqGwfEe6iyfecRwAuGw _71iVEGwfEe6iyfecRwAuGw _8H4ucMwIEe6cROezh8CcIg">
       <target xmi:type="org.polarsys.capella.core.data.information:Class" href="ContextDiagram.capella#322dc599-ea72-49e9-8e37-fe5226e41f19"/>
       <semanticElements xmi:type="org.polarsys.capella.core.data.information:Class" href="ContextDiagram.capella#322dc599-ea72-49e9-8e37-fe5226e41f19"/>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
@@ -8692,6 +8709,38 @@
         </ownedStyle>
         <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@defaultLayer/@containerMappings[name='DT_Class']/@subNodeMappings[name='DT_Property']"/>
       </ownedElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_OrJHoNGCEe6Qjsqma8S9Aw" name="five" incomingEdges="_TMS-qNGCEe6Qjsqma8S9Aw">
+      <target xmi:type="org.polarsys.capella.core.data.information:Class" href="ContextDiagram.capella#37ae6942-cbbc-4e2a-acad-10fbdceb8d56"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.information:Class" href="ContextDiagram.capella#37ae6942-cbbc-4e2a-acad-10fbdceb8d56"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_OrKVwNGCEe6Qjsqma8S9Aw" borderSize="1" borderSizeComputationExpression="1" borderColor="123,105,79" backgroundStyle="Liquid" foregroundColor="232,224,210">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@defaultLayer/@containerMappings[name='DT_Class']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@defaultLayer/@containerMappings[name='DT_Class']"/>
+      <ownedElements xmi:type="diagram:DNodeListElement" uid="_mYwFENGFEe6Qjsqma8S9Aw" name=" fi : EnumExample_5">
+        <target xmi:type="org.polarsys.capella.core.data.information:Property" href="ContextDiagram.capella#c9bc1d96-c40f-4e3d-9824-b38be7a3bd37"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.information:Property" href="ContextDiagram.capella#c9bc1d96-c40f-4e3d-9824-b38be7a3bd37"/>
+        <ownedStyle xmi:type="diagram:Square" uid="_mYwFEdGFEe6Qjsqma8S9Aw" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1" borderColor="136,136,136">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@defaultLayer/@containerMappings[name='DT_Class']/@subNodeMappings[name='DT_Property']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@defaultLayer/@containerMappings[name='DT_Class']/@subNodeMappings[name='DT_Property']"/>
+      </ownedElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_TMS-qNGCEe6Qjsqma8S9Aw" name=" " sourceNode="_UHJUQGwfEe6iyfecRwAuGw" targetNode="_OrJHoNGCEe6Qjsqma8S9Aw" endLabel="five">
+      <target xmi:type="org.polarsys.capella.core.data.information:Association" href="ContextDiagram.capella#58b887af-7fe4-4b52-b877-268ea5ca9417"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.information:Association" href="ContextDiagram.capella#58b887af-7fe4-4b52-b877-268ea5ca9417"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.information:Property" href="ContextDiagram.capella#ebe08ff2-2751-466d-938a-b73c90f27476"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.information:Property" href="ContextDiagram.capella#20b6c308-dc9a-4c83-8c7e-9348ca5f9930"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_TMS-qdGCEe6Qjsqma8S9Aw" strokeColor="0,0,0">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@defaultLayer/@edgeMappings[name='DT_Association']/@conditionnalStyles.0/@style"/>
+        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" uid="_TMS-qtGCEe6Qjsqma8S9Aw" showIcon="false"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_TMS-rNGCEe6Qjsqma8S9Aw"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_TMS-q9GCEe6Qjsqma8S9Aw" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@defaultLayer/@edgeMappings[name='DT_Association']"/>
     </ownedDiagramElements>
     <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']"/>
     <currentConcern xmi:type="concern:ConcernDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@concerns/@ownedConcernDescriptions.0"/>

--- a/tests/data/ContextDiagram.aird
+++ b/tests/data/ContextDiagram.aird
@@ -8,7 +8,7 @@
     </ownedViews>
     <ownedViews xmi:type="viewpoint:DView" uid="__FJxoKDzEeqf7Mw7EIo_Ew">
       <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']"/>
-      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_OmRFoGwfEe6iyfecRwAuGw" name="[CDB] Data" repPath="#_OmIiwGwfEe6iyfecRwAuGw" changeId="8733cf88-652d-4faf-8681-f70453d639a1">
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_OmRFoGwfEe6iyfecRwAuGw" name="[CDB] Data" repPath="#_OmIiwGwfEe6iyfecRwAuGw" changeId="7feceff4-e268-4430-b254-ca7aa5a3e2a9">
         <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']"/>
         <target xmi:type="org.polarsys.capella.core.data.information:DataPkg" href="ContextDiagram.capella#d12c04b6-392f-4761-be5a-e44c688823f6"/>
       </ownedRepresentationDescriptors>
@@ -8200,7 +8200,7 @@
             <styles xmi:type="notation:FilteringStyle" xmi:id="_d-9WlswJEe6cROezh8CcIg"/>
           </children>
           <styles xmi:type="notation:ShapeStyle" xmi:id="_d-9WkcwJEe6cROezh8CcIg" fontName="Fira Code" fontHeight="8"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_d-9WkswJEe6cROezh8CcIg" x="20" y="592"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_d-9WkswJEe6cROezh8CcIg" x="60" y="592"/>
         </children>
         <styles xmi:type="notation:DiagramStyle" xmi:id="_OmWlMmwfEe6iyfecRwAuGw"/>
         <edges xmi:type="notation:Edge" xmi:id="_4vzTMGwfEe6iyfecRwAuGw" type="4001" element="_4vKaAGwfEe6iyfecRwAuGw" source="_PLddYGwfEe6iyfecRwAuGw" target="_RGnigGwfEe6iyfecRwAuGw">
@@ -8243,7 +8243,7 @@
             <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6ZM58WwfEe6iyfecRwAuGw" x="8" y="6"/>
           </children>
           <children xmi:type="notation:Node" xmi:id="_6ZM58mwfEe6iyfecRwAuGw" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6ZM582wfEe6iyfecRwAuGw" x="-32" y="36"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6ZM582wfEe6iyfecRwAuGw" x="10"/>
           </children>
           <styles xmi:type="notation:ConnectorStyle" xmi:id="_6ZMS4WwfEe6iyfecRwAuGw" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
           <styles xmi:type="notation:FontStyle" xmi:id="_6ZMS4mwfEe6iyfecRwAuGw" fontName="Fira Code" fontHeight="8"/>
@@ -8684,7 +8684,7 @@
         <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@defaultLayer/@containerMappings[name='DT_Class']/@conditionnalStyles.1/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@defaultLayer/@containerMappings[name='DT_Class']"/>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_gkLsYMwJEe6cROezh8CcIg" name="[1..*] ex : EnumExample">
+      <ownedElements xmi:type="diagram:DNodeListElement" uid="_gkLsYMwJEe6cROezh8CcIg" name=" ex : EnumExample">
         <target xmi:type="org.polarsys.capella.core.data.information:Property" href="ContextDiagram.capella#271d9bcb-8077-417b-9298-5b8057915b3c"/>
         <semanticElements xmi:type="org.polarsys.capella.core.data.information:Property" href="ContextDiagram.capella#271d9bcb-8077-417b-9298-5b8057915b3c"/>
         <ownedStyle xmi:type="diagram:Square" uid="_gkMTcMwJEe6cROezh8CcIg" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1" borderColor="136,136,136">

--- a/tests/data/ContextDiagram.aird
+++ b/tests/data/ContextDiagram.aird
@@ -8,7 +8,7 @@
     </ownedViews>
     <ownedViews xmi:type="viewpoint:DView" uid="__FJxoKDzEeqf7Mw7EIo_Ew">
       <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']"/>
-      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_OmRFoGwfEe6iyfecRwAuGw" name="[CDB] Data" repPath="#_OmIiwGwfEe6iyfecRwAuGw" changeId="7feceff4-e268-4430-b254-ca7aa5a3e2a9">
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_OmRFoGwfEe6iyfecRwAuGw" name="[CDB] Data" repPath="#_OmIiwGwfEe6iyfecRwAuGw" changeId="8733cf88-652d-4faf-8681-f70453d639a1">
         <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']"/>
         <target xmi:type="org.polarsys.capella.core.data.information:DataPkg" href="ContextDiagram.capella#d12c04b6-392f-4761-be5a-e44c688823f6"/>
       </ownedRepresentationDescriptors>
@@ -8200,7 +8200,7 @@
             <styles xmi:type="notation:FilteringStyle" xmi:id="_d-9WlswJEe6cROezh8CcIg"/>
           </children>
           <styles xmi:type="notation:ShapeStyle" xmi:id="_d-9WkcwJEe6cROezh8CcIg" fontName="Fira Code" fontHeight="8"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_d-9WkswJEe6cROezh8CcIg" x="60" y="592"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_d-9WkswJEe6cROezh8CcIg" x="20" y="592"/>
         </children>
         <styles xmi:type="notation:DiagramStyle" xmi:id="_OmWlMmwfEe6iyfecRwAuGw"/>
         <edges xmi:type="notation:Edge" xmi:id="_4vzTMGwfEe6iyfecRwAuGw" type="4001" element="_4vKaAGwfEe6iyfecRwAuGw" source="_PLddYGwfEe6iyfecRwAuGw" target="_RGnigGwfEe6iyfecRwAuGw">
@@ -8243,7 +8243,7 @@
             <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6ZM58WwfEe6iyfecRwAuGw" x="8" y="6"/>
           </children>
           <children xmi:type="notation:Node" xmi:id="_6ZM58mwfEe6iyfecRwAuGw" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6ZM582wfEe6iyfecRwAuGw" x="10"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6ZM582wfEe6iyfecRwAuGw" x="-32" y="36"/>
           </children>
           <styles xmi:type="notation:ConnectorStyle" xmi:id="_6ZMS4WwfEe6iyfecRwAuGw" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
           <styles xmi:type="notation:FontStyle" xmi:id="_6ZMS4mwfEe6iyfecRwAuGw" fontName="Fira Code" fontHeight="8"/>
@@ -8684,7 +8684,7 @@
         <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@defaultLayer/@containerMappings[name='DT_Class']/@conditionnalStyles.1/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@defaultLayer/@containerMappings[name='DT_Class']"/>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_gkLsYMwJEe6cROezh8CcIg" name=" ex : EnumExample">
+      <ownedElements xmi:type="diagram:DNodeListElement" uid="_gkLsYMwJEe6cROezh8CcIg" name="[1..*] ex : EnumExample">
         <target xmi:type="org.polarsys.capella.core.data.information:Property" href="ContextDiagram.capella#271d9bcb-8077-417b-9298-5b8057915b3c"/>
         <semanticElements xmi:type="org.polarsys.capella.core.data.information:Property" href="ContextDiagram.capella#271d9bcb-8077-417b-9298-5b8057915b3c"/>
         <ownedStyle xmi:type="diagram:Square" uid="_gkMTcMwJEe6cROezh8CcIg" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1" borderColor="136,136,136">

--- a/tests/data/ContextDiagram.capella
+++ b/tests/data/ContextDiagram.capella
@@ -911,7 +911,7 @@ The predator is far away</bodies>
             <ownedMinCard xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
                 id="7c049ec8-4432-49f8-a570-6ea17a4ddd17" value="1"/>
             <ownedMaxCard xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
-                id="480dcffe-2984-4df3-91f5-459cb5943f1c" name="" value="*"/>
+                id="9477652e-d0dc-4834-97f8-575bab9df46e" value="1"/>
           </ownedFeatures>
         </ownedClasses>
         <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:BooleanType"

--- a/tests/data/ContextDiagram.capella
+++ b/tests/data/ContextDiagram.capella
@@ -911,7 +911,7 @@ The predator is far away</bodies>
             <ownedMinCard xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
                 id="7c049ec8-4432-49f8-a570-6ea17a4ddd17" value="1"/>
             <ownedMaxCard xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
-                id="9477652e-d0dc-4834-97f8-575bab9df46e" value="1"/>
+                id="480dcffe-2984-4df3-91f5-459cb5943f1c" name="" value="*"/>
           </ownedFeatures>
         </ownedClasses>
         <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:BooleanType"

--- a/tests/data/ContextDiagram.capella
+++ b/tests/data/ContextDiagram.capella
@@ -801,6 +801,17 @@ The predator is far away</bodies>
                 id="e602823b-c2dc-4f77-a0fd-109956ace053" value="1"/>
           </ownedMembers>
         </ownedAssociations>
+        <ownedAssociations xsi:type="org.polarsys.capella.core.data.information:Association"
+            id="58b887af-7fe4-4b52-b877-268ea5ca9417" name="DataAssociation4" navigableMembers="#20b6c308-dc9a-4c83-8c7e-9348ca5f9930">
+          <ownedMembers xsi:type="org.polarsys.capella.core.data.information:Property"
+              id="ebe08ff2-2751-466d-938a-b73c90f27476" name="three" abstractType="#322dc599-ea72-49e9-8e37-fe5226e41f19"
+              aggregationKind="ASSOCIATION">
+            <ownedMinCard xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="7d10c47b-4bac-4dfc-838f-ab837a91382b" value="1"/>
+            <ownedMaxCard xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="63a6fd94-9a94-43d7-85bb-7926f6919c44" value="1"/>
+          </ownedMembers>
+        </ownedAssociations>
         <ownedClasses xsi:type="org.polarsys.capella.core.data.information:Class"
             id="8164ae8b-36d5-4502-a184-5ec064db4ec3" name="Twist"/>
         <ownedClasses xsi:type="org.polarsys.capella.core.data.information:Class"
@@ -860,15 +871,7 @@ The predator is far away</bodies>
                 id="0e248b93-c547-4401-b0a3-a507d3f1b4a7" value="1"/>
           </ownedFeatures>
           <ownedFeatures xsi:type="org.polarsys.capella.core.data.information:Property"
-              id="ebbf0505-eac3-4552-96f8-de2b06a93f1e" name="another_one_one_one"
-              abstractType="#1f6a60f6-0563-44c4-a0c0-fa24378f1bd4">
-            <ownedMinCard xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
-                id="054c1806-88be-4269-abb6-d05a2c8bb805" value="1"/>
-            <ownedMaxCard xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
-                id="f4041c08-ace0-4e6c-b6ae-894c789a4af9" value="1"/>
-          </ownedFeatures>
-          <ownedFeatures xsi:type="org.polarsys.capella.core.data.information:Property"
-              id="69509f7b-54a2-43ca-958b-ae03ac3d285c" name="last_one" abstractType="#96e696c3-cd4a-481d-a3e5-f5ecbce9233c">
+              id="69509f7b-54a2-43ca-958b-ae03ac3d285c" name="last_one" abstractType="#1f6a60f6-0563-44c4-a0c0-fa24378f1bd4">
             <ownedMinCard xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
                 id="0ae90b2c-c1e4-43a7-9707-07d2199d8bf2" value="1"/>
             <ownedMaxCard xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
@@ -897,6 +900,14 @@ The predator is far away</bodies>
             <ownedMaxCard xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
                 id="34149eb4-d842-4850-904c-6ac88464f292" value="1"/>
           </ownedFeatures>
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.information:Property"
+              id="20b6c308-dc9a-4c83-8c7e-9348ca5f9930" name="five" abstractType="#37ae6942-cbbc-4e2a-acad-10fbdceb8d56"
+              aggregationKind="ASSOCIATION">
+            <ownedMinCard xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="6b2ab17f-302e-43af-a509-a2240601a8da" value="1"/>
+            <ownedMaxCard xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="614ff75a-5191-4cd9-9363-6db5034315c2" value="1"/>
+          </ownedFeatures>
         </ownedClasses>
         <ownedClasses xsi:type="org.polarsys.capella.core.data.information:Class"
             id="0678bda0-3f17-4be4-b6ea-ee368c458015" name="four">
@@ -912,6 +923,16 @@ The predator is far away</bodies>
                 id="7c049ec8-4432-49f8-a570-6ea17a4ddd17" value="1"/>
             <ownedMaxCard xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
                 id="480dcffe-2984-4df3-91f5-459cb5943f1c" name="" value="*"/>
+          </ownedFeatures>
+        </ownedClasses>
+        <ownedClasses xsi:type="org.polarsys.capella.core.data.information:Class"
+            id="37ae6942-cbbc-4e2a-acad-10fbdceb8d56" name="five">
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.information:Property"
+              id="c9bc1d96-c40f-4e3d-9824-b38be7a3bd37" name="fi" abstractType="#96e696c3-cd4a-481d-a3e5-f5ecbce9233c">
+            <ownedMinCard xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="409a1ed7-3279-42d7-86f6-364ac822706a" value="1"/>
+            <ownedMaxCard xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="5be77569-3078-4861-b5c9-78c31f77cc0e" value="1"/>
           </ownedFeatures>
         </ownedClasses>
         <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:BooleanType"

--- a/tests/test_tree_views.py
+++ b/tests/test_tree_views.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2022 Copyright DB InfraGO AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: Apache-2.0
 
+import typing as t
+
 import capellambse
 import pytest
 
@@ -24,12 +26,18 @@ def test_tree_view_gets_rendered_successfully(
 @pytest.mark.parametrize(
     "edgeLabelsSide", ["ALWAYS_DOWN", "DIRECTION_DOWN", "SMART_DOWN"]
 )
+@pytest.mark.parametrize("depth", [None, 1])
+@pytest.mark.parametrize("super", ["ALL", "ROOT"])
+@pytest.mark.parametrize("sub", ["ALL", "ROOT"])
 def test_tree_view_renders_with_additional_params(
     model: capellambse.MelodyModel,
     edgeRouting: str,
     direction: str,
     partitioning: bool,
     edgeLabelsSide: str,
+    depth: int,
+    super: t.Literal["ALL"] | t.Literal["ROOT"],
+    sub: t.Literal["ALL"] | t.Literal["ROOT"],
 ) -> None:
     obj = model.by_uuid(CLASS_UUID)
 
@@ -41,4 +49,7 @@ def test_tree_view_renders_with_additional_params(
         direction=direction,
         partitioning=partitioning,
         edgeLabelsSide=edgeLabelsSide,
+        depth=depth,
+        super=super,
+        sub=sub,
     )


### PR DESCRIPTION
Added more render parameters and fixed the displayed direction of `Generalization` edges.

With the depth parameter the recursion is ended after the first iteration already which speeds up the computation immensely. A whole tree is still computed per default. The generalizations are now disabled on all other nodes than root per default. The original behavior can be set via `super|sub="ALL"`.