### PR TITLE
Show nicer error if cachedir can't be created

### DIFF
--- a/capellambse_context_diagrams/_elkjs.py
+++ b/capellambse_context_diagrams/_elkjs.py
@@ -307,8 +307,15 @@ def _install_npm_package(npm_pkg_name: str, npm_pkg_version: str) -> None:
 
 
 def _install_required_npm_pkg_versions() -> None:
-    if not NODE_HOME.is_dir():
-        NODE_HOME.mkdir(parents=True)
+    try:
+        NODE_HOME.mkdir(parents=True, exist_ok=True)
+    except OSError as err:
+        raise RuntimeError(
+            f"Cannot create elk.js install directory at: {NODE_HOME}.\n"
+            "Make sure that important environment variables"
+            " like $HOME are set correctly.\n"
+            f"Failed due to {type(err).__name__}: {err}"
+        ) from None
     installed = _get_installed_npm_pkg_versions()
     for pkg_name, pkg_version in REQUIRED_NPM_PKG_VERSIONS.items():
         if installed.get(pkg_name) != pkg_version:


### PR DESCRIPTION
If we cannot create the cache directory to install the elk.js dependencies, we used to crash with whatever error message the OS gave us. This can sometimes be misleading, e.g. when the message is talking about missing permissions, but in reality `$HOME` or `$XDG_CACHE_HOME` is simply set to a broken value.

This commit catches an OSError here and instead shows a nicer error message (and also much more concise stack trace) with a concrete hint towards `$HOME`.

This is mostly relevant when running inside a container or as a system service, as it's much easier to accidentally miss some envvars there.