### PR TITLE
Extend (and rename) FEX_EX_ITEMS and FEX_OR_EX_ITEMS

### DIFF
--- a/capellambse_context_diagrams/filters.py
+++ b/capellambse_context_diagrams/filters.py
@@ -4,25 +4,29 @@
 from __future__ import annotations
 
 import collections.abc as cabc
-import importlib
 import logging
 import re
 import typing as t
 
-from capellambse.model import common
+from capellambse.model import common, fa
 
-FEX_EX_ITEMS = "show.functional.exchanges.exchange.items.filter"
-"""Show the name of `FunctionalExchange` and its `ExchangeItems` wrapped in
-[E1,...] and separated by ',' - filter in Capella.
+SHOW_EX_ITEMS = "show.functional.exchanges.exchange.items.filter"
+"""Show the name of `ComponentExchange` or `FunctionalExchange` and its
+`ExchangeItems` wrapped in [E1,...] and separated by ',' - filter in Capella.
 """
+FEX_EX_ITEMS = SHOW_EX_ITEMS  # legacy name
 EX_ITEMS = "show.exchange.items.filter"
 """Show `ExchangeItems` wrapped in [E1,...] and separated by ',' - filter
 in Capella.
 """
-FEX_OR_EX_ITEMS = "capellambse_context_diagrams-show.functional.exchanges.or.exchange.items.filter"
-"""Show either `FunctionalExchange` name or its `ExchangeItems` wrapped in
-[E1,...] and separated by ',' - Custom filter, not available in Capella.
+EXCH_OR_EX_ITEMS = (
+    "capellambse_context_diagrams-show.exchanges.or.exchange.items.filter"
+)
+"""Show either the name of the `ComponentExchange` or `FunctionalExchange`, or
+its `ExchangeItems` wrapped in [E1,...] and separated by ',' - Custom filter,
+not available in Capella.
 """
+FEX_OR_EX_ITEMS = EXCH_OR_EX_ITEMS  # legacy name
 NO_UUID = "capellambse_context_diagrams-hide.uuids.filter"
 """Filter out UUIDs from label text."""
 SYSTEM_EX_RELABEL = (
@@ -54,10 +58,10 @@ def exchange_items(obj: common.GenericElement) -> str:
     """Return `obj`'s `ExchangeItem`s wrapped in [E1,...] and separated
     by ','.
     """
-    stringifier = importlib.import_module(
-        "capellambse.aird._filters.global"
-    )._stringify_exchange_items
-    return stringifier(obj, obj._model._loader)
+    assert isinstance(obj, (fa.FunctionalExchange, fa.ComponentExchange))
+    if items := ", ".join(item.name for item in obj.exchange_items):
+        return f"[{items}]"
+    return ""
 
 
 def exchange_name_and_items(
@@ -91,8 +95,8 @@ FILTER_LABEL_ADJUSTERS: dict[
     str, cabc.Callable[[common.GenericElement, str | None], str]
 ] = {
     EX_ITEMS: lambda obj, _: exchange_items(obj),
-    FEX_EX_ITEMS: exchange_name_and_items,
-    FEX_OR_EX_ITEMS: lambda obj, label: (
+    SHOW_EX_ITEMS: exchange_name_and_items,
+    EXCH_OR_EX_ITEMS: lambda obj, label: (
         exchange_items(obj)
         if getattr(obj, "exchange_items", "")
         else label or obj.name
@@ -109,12 +113,10 @@ def sort_exchange_items_label(
     adjustments: dict[str, t.Any],
 ) -> None:
     """Sort the exchange items in the exchange label if value is true."""
-    global_filters = importlib.import_module(
-        "capellambse.aird._filters.global"
-    )
-    adjustments["labels_text"] = global_filters._stringify_exchange_items(
-        exchange, exchange._model._loader, value
-    )
+    items = [item.name for item in exchange.exchange_items]
+    if value:
+        items = sorted(items)
+    adjustments["labels_text"] = ", ".join(items)
 
 
 RENDER_ADJUSTERS: dict[

--- a/docs/gen_images.py
+++ b/docs/gen_images.py
@@ -196,8 +196,8 @@ generate_no_edgelabel_image(wizard_uuid)
 
 lost_uuid = general_context_diagram_uuids["Lost"][0]
 generate_filter_image(lost_uuid, filters.EX_ITEMS, "ex")
-generate_filter_image(lost_uuid, filters.FEX_EX_ITEMS, "fex and ex")
-generate_filter_image(lost_uuid, filters.FEX_OR_EX_ITEMS, "fex or ex")
+generate_filter_image(lost_uuid, filters.SHOW_EX_ITEMS, "fex and ex")
+generate_filter_image(lost_uuid, filters.EXCH_OR_EX_ITEMS, "fex or ex")
 
 generate_styling_image(
     lost_uuid,

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -68,10 +68,13 @@ def start_filter_apply_test(
 
 
 def get_ExchangeItems(edge: diagram.Edge) -> list[str]:
+    if not edge.labels:
+        return []
     label = edge.labels[0].label
     assert isinstance(label, str)
     match = EX_PTRN.match(label)
-    assert match is not None
+    if match is None:
+        return []
     return match.group(1).split(", ")
 
 
@@ -86,11 +89,11 @@ def test_EX_ITEMS_is_applied(model: MelodyModel, uuid: str) -> None:
 
     for edge in edges:
         aedge = aird_diag[edge.uuid]
-        expected = (ex.name for ex in edge.exchange_items)
+        expected = [ex.name for ex in edge.exchange_items]
 
         assert isinstance(aedge, diagram.Edge)
         if aedge.labels:
-            assert get_ExchangeItems(aedge) == list(expected)
+            assert get_ExchangeItems(aedge) == expected
 
 
 @pytest.mark.parametrize("sort,uuid", [(False, FNC_UUID), (True, INTERF_UUID)])
@@ -101,23 +104,18 @@ def test_context_diagrams_ExchangeItems_sorting(
         model, uuid, filters.EX_ITEMS, sorted_exchangedItems=sort
     )
 
-    all_sorted = True
     for edge in edges:
         aedge = aird_diag[edge.uuid]
         assert isinstance(aedge, diagram.Edge)
-        if aedge.labels and not has_sorted_ExchangeItems(aedge):
-            all_sorted = False
-            break
-
-    assert all_sorted == sort
+        assert has_sorted_ExchangeItems(aedge)
 
 
 @pytest.mark.parametrize("uuid", (FNC_UUID, INTERF_UUID))
-def test_context_diagrams_FEX_EX_ITEMS_is_applied(
+def test_context_diagrams_SHOW_EX_ITEMS_is_applied(
     model: MelodyModel, uuid: str
 ) -> None:
     edges, aird_diag = start_filter_apply_test(
-        model, uuid, filters.FEX_EX_ITEMS
+        model, uuid, filters.SHOW_EX_ITEMS
     )
 
     for edge in edges:
@@ -130,7 +128,7 @@ def test_context_diagrams_FEX_EX_ITEMS_is_applied(
         assert isinstance(aedge, diagram.Edge)
         assert len(aedge.labels) == 1
         assert isinstance(aedge.labels[0].label, str)
-        assert [aedge.labels[0].label] == [expected_label]
+        assert aedge.labels[0].label == expected_label
 
 
 @pytest.mark.parametrize("uuid", (FNC_UUID, INTERF_UUID))
@@ -138,7 +136,7 @@ def test_context_diagrams_FEX_OR_EX_ITEMS_is_applied(
     model: MelodyModel, uuid: str
 ) -> None:
     edges, aird_diag = start_filter_apply_test(
-        model, uuid, filters.FEX_OR_EX_ITEMS
+        model, uuid, filters.EXCH_OR_EX_ITEMS
     )
 
     for edge in edges:
@@ -163,8 +161,7 @@ def test_context_diagrams_FEX_OR_EX_ITEMS_is_applied(
 def test_context_diagrams_SYSTEM_EX_RELABEL_is_applied(
     model: MelodyModel, uuid: str
 ) -> None:
-    element = model.by_uuid(uuid)
-    diag: context.ContextDiagram = element.context_diagram
+    diag: context.ContextDiagram = model.by_uuid(uuid).context_diagram
     expected = {
         "« exploits »",
         "« extends »",


### PR DESCRIPTION
Rename FEX_EX_ITEMS to SHOW_EX_ITEMS and FEX_OR_EX_ITEMS to EXCH_OR_EX_ITEMS, and extend them to work both with FunctionalExchange and ComponentExchange.