### PR TITLE
Upgrade to capellambse v0.6.x

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,15 @@ repos:
     rev: v1.11.1
     hooks:
       - id: mypy
+        args: [--follow-imports=silent]
+        additional_dependencies:
+          - capellambse==0.6.5
+          - mkdocs
+          - mkdocs-gen-files
+          - mkdocs-literate-nav
+          - pydantic==2.7.3
+          - pytest
+          - types-setuptools
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.5
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
       - id: mypy
         args: [--follow-imports=silent]
         additional_dependencies:
-          - capellambse==0.6.5
+          - capellambse==0.6.6
           - mkdocs
           - mkdocs-gen-files
           - mkdocs-literate-nav

--- a/capellambse_context_diagrams/_elkjs.py
+++ b/capellambse_context_diagrams/_elkjs.py
@@ -206,6 +206,7 @@ class ELKOutputNode(ELKOutputDiagramElement):
     children: cabc.MutableSequence[ELKOutputChild] = pydantic.Field(
         default_factory=list
     )
+    context: list[str] = pydantic.Field(default_factory=list)
 
 
 class ELKOutputJunction(ELKOutputElement):
@@ -217,6 +218,7 @@ class ELKOutputJunction(ELKOutputElement):
     )
 
     position: ELKPoint
+    context: list[str] = pydantic.Field(default_factory=list)
 
 
 class ELKOutputPort(ELKOutputDiagramElement):
@@ -226,6 +228,7 @@ class ELKOutputPort(ELKOutputDiagramElement):
     children: cabc.MutableSequence[ELKOutputLabel] = pydantic.Field(
         default_factory=list
     )
+    context: list[str] = pydantic.Field(default_factory=list)
 
 
 class ELKOutputLabel(ELKOutputDiagramElement):
@@ -233,6 +236,7 @@ class ELKOutputLabel(ELKOutputDiagramElement):
 
     type: t.Literal["label"]
     text: str
+    context: list[str] = pydantic.Field(default_factory=list)
 
 
 class ELKOutputEdge(ELKOutputElement):
@@ -246,6 +250,7 @@ class ELKOutputEdge(ELKOutputElement):
     children: cabc.MutableSequence[
         t.Union[ELKOutputLabel, ELKOutputJunction]
     ] = pydantic.Field(default_factory=list)
+    context: list[str] = pydantic.Field(default_factory=list)
 
 
 ELKOutputChild = t.Union[

--- a/capellambse_context_diagrams/collectors/dataflow_view.py
+++ b/capellambse_context_diagrams/collectors/dataflow_view.py
@@ -10,16 +10,15 @@ import operator
 import typing as t
 from itertools import chain
 
-from capellambse.model import modeltypes
-from capellambse.model.crosslayer import fa
-from capellambse.model.layers import oa
+import capellambse.model as m
+from capellambse.metamodel import fa, oa
 
 from .. import _elkjs, context
 from . import default, generic, makers, portless
 
-COLLECTOR_PARAMS: dict[modeltypes.DiagramType, dict[str, t.Any]] = {
-    modeltypes.DiagramType.OAIB: {"attribute": "involved_activities"},
-    modeltypes.DiagramType.SDFB: {
+COLLECTOR_PARAMS: dict[m.DiagramType, dict[str, t.Any]] = {
+    m.DiagramType.OAIB: {"attribute": "involved_activities"},
+    m.DiagramType.SDFB: {
         "attribute": "involved_functions",
         "filter_attrs": ("source.owner", "target.owner"),
         "port_collector": default.port_collector,

--- a/capellambse_context_diagrams/collectors/exchanges.py
+++ b/capellambse_context_diagrams/collectors/exchanges.py
@@ -9,9 +9,9 @@ import logging
 import operator
 import typing as t
 
-from capellambse.model import common
-from capellambse.model.crosslayer import cs, fa
-from capellambse.model.modeltypes import DiagramType as DT
+import capellambse.model as m
+from capellambse.metamodel import cs, fa
+from capellambse.model import DiagramType as DT
 
 from .. import _elkjs, context
 from . import generic, makers
@@ -130,8 +130,8 @@ class InterfaceContextCollector(ExchangeCollector):
     """Left (source) Component Box of the interface."""
     right: _elkjs.ELKInputChild | None
     """Right (target) Component Box of the interface."""
-    outgoing_edges: dict[str, common.GenericElement]
-    incoming_edges: dict[str, common.GenericElement]
+    outgoing_edges: dict[str, m.ModelElement]
+    incoming_edges: dict[str, m.ModelElement]
 
     def __init__(
         self,
@@ -216,7 +216,7 @@ class InterfaceContextCollector(ExchangeCollector):
         obj: fa.AbstractFunction | fa.FunctionPort,
         boxes: dict[str, _elkjs.ELKInputChild],
     ) -> str:
-        owners: list[common.GenericElement] = []
+        owners: list[m.ModelElement] = []
         assert self.right is not None and self.left is not None
         root: _elkjs.ELKInputChild | None = None
         for uuid in generic.get_all_owners(obj):
@@ -230,7 +230,7 @@ class InterfaceContextCollector(ExchangeCollector):
         if root is None:
             raise ValueError(f"No root found for {obj._short_repr_()}")
 
-        owner_box = root
+        owner_box: _elkjs.ELKInputChild = root
         for owner in reversed(owners):
             if isinstance(owner, fa.FunctionPort):
                 if owner.uuid in (p.id for p in owner_box.ports):
@@ -321,7 +321,7 @@ class FunctionalContextCollector(ExchangeCollector):
 
 
 def is_hierarchical(
-    ex: common.GenericElement,
+    ex: m.ModelElement,
     box: _elkjs.ELKInputChild,
     key: t.Literal["ports"] | t.Literal["children"] = "ports",
 ) -> bool:

--- a/capellambse_context_diagrams/collectors/makers.py
+++ b/capellambse_context_diagrams/collectors/makers.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 
 import collections.abc as cabc
 
+import capellambse.model as m
 import typing_extensions as te
 from capellambse import helpers as chelpers
-from capellambse.model import common, layers
+from capellambse.metamodel import oa, sa
 from capellambse.svg import helpers as svghelpers
 from capellambse.svg.decorations import icon_padding, icon_size
 
@@ -42,10 +43,10 @@ SYMBOL_RATIO = MIN_SYMBOL_WIDTH / MIN_SYMBOL_HEIGHT
 FAULT_PAD = 10
 """Height adjustment for labels."""
 BOX_TO_SYMBOL = (
-    layers.ctx.Capability.__name__,
-    layers.oa.OperationalCapability.__name__,
-    layers.ctx.Mission.__name__,
-    layers.ctx.SystemComponent.__name__,
+    sa.Capability.__name__,
+    oa.OperationalCapability.__name__,
+    sa.Mission.__name__,
+    sa.SystemComponent.__name__,
     "SystemHumanActor",
     "SystemActor",
 )
@@ -94,7 +95,7 @@ def make_label(
     """
     label_width, label_height = chelpers.get_text_extent(text)
     icon_width, _ = icon
-    lines = [text]
+    lines: cabc.Sequence[str] = [text]
     if max_width is not None and label_width > max_width:
         lines, _, _ = svghelpers.check_for_horizontal_overflow(
             text,
@@ -129,14 +130,14 @@ class _LabelBuilder(te.TypedDict, total=True):
 
 
 def make_box(
-    obj: common.GenericElement,
+    obj: m.ModelElement,
     *,
     width: int | float = 0,
     height: int | float = 0,
     no_symbol: bool = False,
     slim_width: bool = True,
     label_getter: cabc.Callable[
-        [common.GenericElement], cabc.Iterable[_LabelBuilder]
+        [m.ModelElement], cabc.Iterable[_LabelBuilder]
     ] = lambda i: [
         {
             "text": i.name,
@@ -198,7 +199,7 @@ def calculate_height_and_width(
     return width, max(height, _height)
 
 
-def is_symbol(obj: str | common.GenericElement | None) -> bool:
+def is_symbol(obj: str | m.ModelElement | None) -> bool:
     """Check if given `obj` is rendered as a Symbol instead of a Box."""
     if obj is None:
         return False

--- a/capellambse_context_diagrams/collectors/realization_view.py
+++ b/capellambse_context_diagrams/collectors/realization_view.py
@@ -9,9 +9,8 @@ import copy
 import re
 import typing as t
 
-from capellambse.model import common, crosslayer
-from capellambse.model.crosslayer import cs, fa
-from capellambse.model.layers import oa
+import capellambse.model as m
+from capellambse.metamodel import cs, fa, oa
 
 from .. import _elkjs, context
 from . import makers
@@ -117,21 +116,21 @@ def collector(
 
 
 def collect_realized(
-    start: common.GenericElement, depth: int
+    start: m.ModelElement, depth: int
 ) -> dict[LayerLiteral, list[dict[str, t.Any]]]:
     """Collect all elements from ``realized_`` attributes up to depth."""
     return collect_elements(start, depth, "ABOVE", "realized")
 
 
 def collect_realizing(
-    start: common.GenericElement, depth: int
+    start: m.ModelElement, depth: int
 ) -> dict[LayerLiteral, list[dict[str, t.Any]]]:
     """Collect all elements from ``realizing_`` attributes down to depth."""
     return collect_elements(start, depth, "BELOW", "realizing")
 
 
 def collect_all(
-    start: common.GenericElement, depth: int
+    start: m.ModelElement, depth: int
 ) -> dict[LayerLiteral, list[dict[str, t.Any]]]:
     """Collect all elements in both ABOVE and BELOW directions."""
     above = collect_realized(start, depth)
@@ -140,11 +139,11 @@ def collect_all(
 
 
 def collect_elements(
-    start: common.GenericElement,
+    start: m.ModelElement,
     depth: int,
     direction: str,
     attribute_prefix: str,
-    origin: common.GenericElement | None = None,
+    origin: m.ModelElement | None = None,
 ) -> dict[LayerLiteral, list[dict[str, t.Any]]]:
     """Collect elements based on the specified direction and attribute name."""
     layer_obj, layer = find_layer(start)
@@ -198,8 +197,8 @@ LayerLiteral = t.Union[
 
 
 def find_layer(
-    obj: common.GenericElement,
-) -> tuple[crosslayer.BaseArchitectureLayer, LayerLiteral]:
+    obj: m.ModelElement,
+) -> tuple[cs.ComponentArchitecture, LayerLiteral]:
     """Return the layer object and its literal.
 
     Return either one of the following:
@@ -209,7 +208,7 @@ def find_layer(
       * ``Physical``
     """
     parent = obj
-    while not isinstance(parent, crosslayer.BaseArchitectureLayer):
+    while not isinstance(parent, cs.ComponentArchitecture):
         parent = parent.parent
     if not (match := RE_LAYER_PTRN.match(type(parent).__name__)):
         raise ValueError("No layer was found.")
@@ -217,7 +216,7 @@ def find_layer(
 
 
 Collector = cabc.Callable[
-    [common.GenericElement, int], dict[LayerLiteral, list[dict[str, t.Any]]]
+    [m.ModelElement, int], dict[LayerLiteral, list[dict[str, t.Any]]]
 ]
 COLLECTORS: dict[str, Collector] = {
     "ALL": collect_all,

--- a/capellambse_context_diagrams/collectors/tree_view.py
+++ b/capellambse_context_diagrams/collectors/tree_view.py
@@ -10,8 +10,8 @@ import logging
 import math
 import typing as t
 
-from capellambse.model import common
-from capellambse.model.crosslayer import information
+import capellambse.model as m
+from capellambse.metamodel import information
 
 from .. import _elkjs, context
 from . import generic, makers
@@ -54,7 +54,7 @@ class ClassProcessor:
             edges = [
                 assoc
                 for assoc in self.all_associations
-                if cls.prop in list(assoc.navigable_members)
+                if cls.prop in assoc.navigable_members  # type: ignore[attr-defined]
             ]
             edge_id = edges[0].uuid
             if edge_id not in self.made_edges:
@@ -92,13 +92,19 @@ class ClassProcessor:
                 )
 
     def _process_box(
-        self, obj: information.Class, partition: int, params: dict[str, t.Any]
+        self,
+        obj: information.Class,
+        partition: int,
+        params: dict[str, t.Any],
     ) -> None:
         if obj.uuid not in self.made_boxes:
             self._make_box(obj, partition, params)
 
     def _make_box(
-        self, obj: information.Class, partition: int, params: dict[str, t.Any]
+        self,
+        obj: information.Class,
+        partition: int,
+        params: dict[str, t.Any],
     ) -> _elkjs.ELKInputChild:
         self.made_boxes.add(obj.uuid)
         box = makers.make_box(
@@ -268,7 +274,7 @@ def get_all_classes(
             for prop in root.super.owned_properties:
                 process_property(
                     _PropertyInfo(
-                        root.super,
+                        root.super,  # type: ignore[arg-type]
                         prop,
                         partition + 1,
                         classes,
@@ -282,11 +288,14 @@ def get_all_classes(
             edge_id = f"{root.uuid} {root.super.uuid}"
             if edge_id not in classes:
                 classes[edge_id] = _make_class_info(
-                    root.super, None, partition, generalizes=root
+                    root.super,  # type: ignore[arg-type]
+                    None,
+                    partition,
+                    generalizes=root,
                 )
                 classes.update(
                     get_all_classes(
-                        root.super,
+                        root.super,  # type: ignore[arg-type]
                         partition,
                         classes,
                         max_partition,
@@ -344,7 +353,7 @@ def _make_class_info(
     return ClassInfo(
         source=source,
         target=target,
-        prop=prop,
+        prop=prop,  # type: ignore[arg-type]
         partition=partition,
         multiplicity=multiplicity,
         generalizes=generalizes,
@@ -419,7 +428,7 @@ def _get_property_text(prop: information.Property) -> str:
 
 
 def _get_legend_labels(
-    obj: common.GenericElement,
+    obj: m.ModelElement,
 ) -> cabc.Iterator[makers._LabelBuilder]:
     yield {
         "text": obj.name,

--- a/capellambse_context_diagrams/filters.py
+++ b/capellambse_context_diagrams/filters.py
@@ -8,7 +8,8 @@ import logging
 import re
 import typing as t
 
-from capellambse.model import common, fa
+import capellambse.model as m
+from capellambse.metamodel import fa
 
 SHOW_EX_ITEMS = "show.functional.exchanges.exchange.items.filter"
 """Show the name of `ComponentExchange` or `FunctionalExchange` and its
@@ -52,7 +53,7 @@ LABEL_CONVERSION: t.Final[dict[str, str]] = {
 """A map that for relabelling specific ModelObject types."""
 
 
-def exchange_items(obj: common.GenericElement) -> str:
+def exchange_items(obj: m.ModelElement) -> str:
     """Return `obj`'s `ExchangeItem`s wrapped in [E1,...] and separated
     by ','.
     """
@@ -63,7 +64,7 @@ def exchange_items(obj: common.GenericElement) -> str:
 
 
 def exchange_name_and_items(
-    obj: common.GenericElement, label: str | None = None
+    obj: m.ModelElement, label: str | None = None
 ) -> str:
     """Return `obj`'s name and `ExchangeItem`s if there are any."""
     label = label or obj.name
@@ -72,16 +73,14 @@ def exchange_name_and_items(
     return label
 
 
-def uuid_filter(obj: common.GenericElement, label: str | None = None) -> str:
+def uuid_filter(obj: m.ModelElement, label: str | None = None) -> str:
     """Return `obj`'s name or `obj` if string w/o UUIDs in it."""
     filtered_label = label if label is not None else obj.name
     assert isinstance(filtered_label, str)
     return UUID_PTRN.sub("", filtered_label)
 
 
-def relabel_system_exchange(
-    obj: common.GenericElement, label: str | None
-) -> str:
+def relabel_system_exchange(obj: m.ModelElement, label: str | None) -> str:
     """Return converted label from obj, a system exchanges."""
     label_map = LABEL_CONVERSION
     if patch := label_map.get(type(obj).__name__):
@@ -90,7 +89,7 @@ def relabel_system_exchange(
 
 
 FILTER_LABEL_ADJUSTERS: dict[
-    str, cabc.Callable[[common.GenericElement, str | None], str]
+    str, cabc.Callable[[m.ModelElement, str | None], str]
 ] = {
     EX_ITEMS: lambda obj, _: exchange_items(obj),
     SHOW_EX_ITEMS: exchange_name_and_items,
@@ -107,7 +106,7 @@ FILTER_LABEL_ADJUSTERS: dict[
 
 def sort_exchange_items_label(
     value: bool,
-    exchange: common.GenericElement,
+    exchange: m.ModelElement,
     adjustments: dict[str, t.Any],
 ) -> None:
     """Sort the exchange items in the exchange label if value is true."""
@@ -118,6 +117,6 @@ def sort_exchange_items_label(
 
 
 RENDER_ADJUSTERS: dict[
-    str, cabc.Callable[[bool, common.GenericElement, dict[str, t.Any]], None]
+    str, cabc.Callable[[bool, m.ModelElement, dict[str, t.Any]], None]
 ] = {"sorted_exchangedItems": sort_exchange_items_label}
 """Available custom render parameter-solvers registry."""

--- a/capellambse_context_diagrams/serializers.py
+++ b/capellambse_context_diagrams/serializers.py
@@ -370,8 +370,7 @@ def handle_features(child: _elkjs.ELKOutputNode) -> list[str]:
 
 
 def route_shortest_connection(
-    source: cdiagram.Box,
-    target: cdiagram.Box,
+    source: cdiagram.Box, target: cdiagram.Box
 ) -> list[cdiagram.Vector2D]:
     """Calculate shortest path between boxes with 'Oblique' style.
 

--- a/capellambse_context_diagrams/styling.py
+++ b/capellambse_context_diagrams/styling.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 import typing as t
 
 from capellambse import diagram
+from capellambse import model as m
 from capellambse.diagram import capstyle
-from capellambse.model import common
 
 if t.TYPE_CHECKING:
     from . import serializers
@@ -24,14 +24,14 @@ See also
 [parent_is_actor_fills_blue][capellambse_context_diagrams.styling.parent_is_actor_fills_blue]
 """
 Styler = t.Callable[
-    [common.GenericElement, "serializers.DiagramSerializer"],
+    [m.ModelElement, "serializers.DiagramSerializer"],
     t.Union[diagram.StyleOverrides, None],
 ]
 """Function that produces `CSSStyles` for given obj."""
 
 
 def parent_is_actor_fills_blue(
-    obj: common.GenericElement, serializer: serializers.DiagramSerializer
+    obj: m.ModelElement, serializer: serializers.DiagramSerializer
 ) -> CSSStyles:
     """Return ``CSSStyles`` for given ``obj`` rendering it blue."""
     del serializer
@@ -51,7 +51,7 @@ def parent_is_actor_fills_blue(
 
 
 def style_center_symbol(
-    obj: common.GenericElement, serializer: serializers.DiagramSerializer
+    obj: m.ModelElement, serializer: serializers.DiagramSerializer
 ) -> CSSStyles:
     """Return ``CSSStyles`` for given ``obj``."""
     if obj != serializer._diagram.target:  # type: ignore[has-type]
@@ -59,7 +59,7 @@ def style_center_symbol(
     return {
         "fill": capstyle.COLORS["white"],
         "stroke": capstyle.COLORS["gray"],
-        "stroke-dasharray": 3,
+        "stroke-dasharray": "3",
     }
 
 

--- a/docs/gen_ref_pages.py
+++ b/docs/gen_ref_pages.py
@@ -24,7 +24,7 @@ for path in sorted(Path(src).rglob("*.py")):
     if filename == "__main__":
         continue
 
-    nav[parts] = doc_path.as_posix()
+    nav[tuple(parts)] = doc_path.as_posix()
 
     with mkdocs_gen_files.open(full_doc_path, "w") as fd:
         identifier = ".".join(parts)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-  "capellambse>=0.5.9,<0.6",
+  "capellambse>=0.6.5,<0.7",
   "typing_extensions",
   "pydantic>=2.7.3"
 ]
@@ -78,8 +78,8 @@ python_version = "3.11"
 
 [[tool.mypy.overrides]]
 module = ["tests.*"]
-allow_incomplete_defs = true
-allow_untyped_defs = true
+disallow_incomplete_defs = false
+disallow_untyped_defs = false
 
 [tool.pydocstyle]
 convention = "numpy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,10 @@ build-backend = "setuptools.build_meta"
 dynamic = ["version"]
 
 name = "capellambse-context-diagrams"
-description = "Extension for python-capella-mbse that adds automatically generated context diagrams for arbitrary model elements."
+description = "Extension for py-capellambse that adds automatically generated context diagrams for arbitrary model elements."
 readme = "README.md"
 requires-python = ">=3.10"
-license = { file = "LICENSES/Apache-2.0.txt" }
+license.text = "Apache-2.0"
 authors = [
   { name = "DB InfraGO AG" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-  "capellambse>=0.6.5,<0.7",
+  "capellambse>=0.6.6,<0.7",
   "typing_extensions",
   "pydantic>=2.7.3"
 ]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,0 @@
-# SPDX-FileCopyrightText: 2022 Copyright DB InfraGO AG and the capellambse-context-diagrams contributors
-# SPDX-License-Identifier: Apache-2.0

--- a/tests/test_capability_diagrams.py
+++ b/tests/test_capability_diagrams.py
@@ -2,13 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import capellambse
+import capellambse.metamodel as mm
 import pytest
-from capellambse.model.layers import ctx, oa
 
 # pylint: disable-next=relative-beyond-top-level, useless-suppression
 from .conftest import SYSTEM_ANALYSIS_PARAMS  # type: ignore[import]
 
-TEST_TYPES = (oa.OperationalCapability, ctx.Capability, ctx.Mission)
+TEST_TYPES = (mm.oa.OperationalCapability, mm.sa.Capability, mm.sa.Mission)
 
 
 @pytest.mark.parametrize("uuid", SYSTEM_ANALYSIS_PARAMS)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -6,9 +6,9 @@ from __future__ import annotations
 import re
 import typing as t
 
+import capellambse.metamodel as mm
 import pytest
 from capellambse import MelodyModel, diagram
-from capellambse.model import crosslayer
 
 from capellambse_context_diagrams import context, filters
 
@@ -20,9 +20,7 @@ CAP_EXPLOIT = "4513c8cd-b94b-4bde-bd00-4c18aaf600ff"
 FNC_UUID = "a5642060-c9cc-4d49-af09-defaa3024bae"
 INTERF_UUID = "9cbdd233-aff5-47dd-9bef-9be1277c77c3"
 
-Types = list[
-    t.Union[crosslayer.fa.FunctionalExchange, crosslayer.fa.ComponentExchange]
-]
+Types = list[t.Union[mm.fa.FunctionalExchange, mm.fa.ComponentExchange]]
 
 
 @pytest.mark.parametrize(
@@ -58,10 +56,7 @@ def start_filter_apply_test(
         for elt in diag.nodes
         if isinstance(
             elt,
-            (
-                crosslayer.fa.FunctionalExchange,
-                crosslayer.fa.ComponentExchange,
-            ),
+            (mm.fa.FunctionalExchange, mm.fa.ComponentExchange),
         )
     ]
     return edges, diag.render(None, **render_params)

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -13,10 +13,9 @@ from capellambse_context_diagrams.collectors import makers
         pytest.param(
             "d817767f-68b7-49a5-aa47-13419d41df0a",
             [
-                "Really long label that",
-                "needs wrapping else",
-                "its parent box is also",
-                "very long!",
+                "Really long label that needs",
+                "wrapping else its parent box is",
+                "also very long!",
             ],
             id="LogicalFunction",
         ),
@@ -29,4 +28,5 @@ def test_context_diagrams(
 
     labels = makers.make_label(obj.name, max_width=makers.MAX_LABEL_WIDTH)
 
-    assert [label.text for label in labels] == expected_labels
+    actual = [label.text for label in labels]
+    assert actual == expected_labels


### PR DESCRIPTION
This PR migrates the codebase to the new import structure and changed class names in capellambse v0.6.x.

The diff is a bit inflated, as I also took the opportunity to unify the imports, and also repair the mypy hook (so I could rely on it during the migration). The latter uncovered a variety of type errors, which I then also went ahead and fixed. I didn't touch any of the logic (as far as I could), so there shouldn't be any breakage.

I've marked the commit as breaking change, to try and make downstream more aware of this upgrade.