### PR TITLE
Improve logging

### DIFF
--- a/capellambse_context_diagrams/collectors/exchanges.py
+++ b/capellambse_context_diagrams/collectors/exchanges.py
@@ -177,7 +177,7 @@ class InterfaceContextCollector(ExchangeCollector):
             try:
                 src_id = self.make_all_owners(fex.source, boxes)
             except ValueError as error:
-                logger.warning(error.args[0])
+                logger.debug("%s", error)
                 continue
 
             try:
@@ -185,7 +185,7 @@ class InterfaceContextCollector(ExchangeCollector):
             except ValueError as error:
                 src_port = boxes[fex.source.owner.uuid].ports.pop()
                 assert src_port.id == fex.source.uuid
-                logger.warning(error.args[0])
+                logger.debug("%s", error)
                 continue
 
             if [src_id, trg_id] == [self.right.id, self.left.id]:

--- a/capellambse_context_diagrams/collectors/tree_view.py
+++ b/capellambse_context_diagrams/collectors/tree_view.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2022 Copyright DB InfraGO AG and the capellambse-context-diagrams contributors
 # SPDX-License-Identifier: Apache-2.0
 """This submodule defines the collector for the Class-Tree diagram."""
+
 from __future__ import annotations
 
 import collections.abc as cabc
@@ -211,13 +212,11 @@ def process_property(
     """Process a single property for class information."""
     prop = property.prop
     if not prop.type:
-        logger.warning(
-            "Property without abstract type found: %r", prop._short_repr_()
-        )
+        logger.debug("Ignoring property without type: %s", prop._short_repr_())
         return
 
     if not prop.type.xtype.endswith("Class") or prop.type.is_primitive:
-        logger.debug("Ignoring non-class property: %r", prop._short_repr_())
+        logger.debug("Ignoring non-class property: %s", prop._short_repr_())
         return
 
     if (
@@ -411,13 +410,10 @@ def _get_all_non_edge_properties(
 
 
 def _get_property_text(prop: information.Property) -> str:
-    text = prop.name
     if prop.type is not None:
         text = f"{prop.name}: {prop.type.name}"
     else:
-        logger.warning(
-            "Property without abstract type found: %r", prop._short_repr_()
-        )
+        text = f"{prop.name}: <untyped>"
 
     min_card = getattr(prop.min_card, "value", "1")
     max_card = getattr(prop.max_card, "value", "1")


### PR DESCRIPTION
Improve logging formatting, and reduce some warnings about modelling issues down to debug level.

This helps reduce noise, especially during CI runs that generate context diagrams as part of it (e.g. when rendering some documents out of the model).