### PR TITLE
Only include code in the wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,7 +182,7 @@ zip-safe = false
 "*" = ["py.typed", "*.js"]
 
 [tool.setuptools.packages.find]
-exclude = ["LICENSES"]
+include = ["capellambse_context_diagrams", "capellambse_context_diagrams.*"]
 
 [tool.setuptools_scm]
 # This section must exist for setuptools_scm to work


### PR DESCRIPTION
The wheel used to also include the documentation, which unhelpfully got installed into `.../site-packages/docs`. This commit fixes that by changing the package declaration for setuptools: instead of excluding what we don't want, we now include explicitly only the actual code packages. This still makes use of setuptools' discovery to find the individual submodules of capellambse_context_diagrams, but it won't try to find code anywhere else.