### PR TITLE
refactor: Use custom collector for default context

### DIFF
--- a/docs/extras/derived.md
+++ b/docs/extras/derived.md
@@ -12,8 +12,8 @@ i.e. the system of interest on which `context_diagram` was called on. The
 render parameter to enable this feature is called `display_derived_interfaces`
 and is available on:
 
-- `LogicalComponent`s and
-- `SystemComponent`s
+-   `LogicalComponent`s and
+-   `SystemComponent`s
 
 !!! example "Context Diagram with derived elements"
 
@@ -32,6 +32,6 @@ and is available on:
     </figure>
 
 See [`the derivator
-functions`][capellambse_context_diagrams.collectors.default.DERIVATORS] to gain
+functions`][capellambse_context_diagrams.collectors.custom.DERIVATORS] to gain
 an overview over all supported capellambse types and the logic to derive
 elements.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ context_diagrams = "capellambse_context_diagrams:init"
 [dependency-groups]
 dev = [
   "coverage>=7.6.9",
+  "ipykernel>=6.29.5",
   "pre-commit>=4.0.1",
   "pyls-isort>=0.2.2",
   "pylsp-mypy>=0.6.9",

--- a/src/capellambse_context_diagrams/__init__.py
+++ b/src/capellambse_context_diagrams/__init__.py
@@ -354,5 +354,5 @@ def register_custom_diagram() -> None:
         m.set_accessor(
             class_,
             "custom_diagram",
-            context.CustomContextAccessor(dgcls.value, {}),
+            context.CustomAccessor(dgcls.value, {}),
         )

--- a/src/capellambse_context_diagrams/collectors/__init__.py
+++ b/src/capellambse_context_diagrams/collectors/__init__.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_elkdata(
-    diagram: context.ContextDiagram, params: dict[str, t.Any] | None = None
+    diagram: context.ContextDiagram, params: dict[str, t.Any]
 ) -> _elkjs.ELKInputData:
     """High level collector function to collect needed data for ELK.
 

--- a/src/capellambse_context_diagrams/collectors/custom.py
+++ b/src/capellambse_context_diagrams/collectors/custom.py
@@ -151,11 +151,8 @@ class CustomCollector:
             for edge_uuid in edges[side]:
                 flip(edge_uuid)
 
-        if self.diagram._unify_edge_direction == "TREE":
-            flip_small_side(self.edges_to_flip[self.boxable_target.uuid])
-        else:
-            for edges in self.edges_to_flip.values():
-                flip_small_side(edges)
+        for edges in self.edges_to_flip.values():
+            flip_small_side(edges)
 
     def _fix_box_heights(self) -> None:
         if self.diagram._unify_edge_direction != "NONE":

--- a/src/capellambse_context_diagrams/collectors/custom.py
+++ b/src/capellambse_context_diagrams/collectors/custom.py
@@ -27,7 +27,7 @@ class CustomCollector:
 
     def __init__(
         self,
-        diagram: context.ContextDiagram,
+        diagram: context.CustomDiagram,
         params: dict[str, t.Any],
     ) -> None:
         self.diagram = diagram
@@ -138,8 +138,10 @@ class CustomCollector:
             for attr in generic.DIAGRAM_TYPE_TO_CONNECTOR_NAMES[
                 self.diagram.type
             ]:
-                for port in getattr(obj, attr, []):
-                    self._make_port_and_owner(port)
+                for port_obj in getattr(obj, attr, []):
+                    port = self._make_port_and_owner(port_obj)
+                    side = "left" if attr == "inputs" else "right"
+                    self._update_min_heights(obj.uuid, side, port)
         if self.diagram._display_parent_relation:
             self.common_owners.add(
                 generic.make_owner_boxes(
@@ -286,7 +288,7 @@ class CustomCollector:
 
 
 def collector(
-    diagram: context.ContextDiagram, params: dict[str, t.Any]
+    diagram: context.CustomDiagram, params: dict[str, t.Any]
 ) -> _elkjs.ELKInputData:
     """Collect data for rendering a custom diagram."""
     return CustomCollector(diagram, params)()

--- a/src/capellambse_context_diagrams/collectors/custom.py
+++ b/src/capellambse_context_diagrams/collectors/custom.py
@@ -5,13 +5,32 @@
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import copy
 import typing as t
 
 import capellambse.model as m
+from capellambse.metamodel import cs, fa, la, sa
 
 from .. import _elkjs, context
-from . import generic, makers
+from . import default, generic, makers
+
+if t.TYPE_CHECKING:
+    from .. import context
+
+    DerivatorFunction: t.TypeAlias = cabc.Callable[
+        [
+            context.CustomDiagram,
+            _elkjs.ELKInputData,
+            dict[str, _elkjs.ELKInputChild],
+        ],
+        None,
+    ]
+
+    Filter: t.TypeAlias = cabc.Callable[
+        [cabc.Iterable[m.ModelElement]],
+        cabc.Iterable[m.ModelElement],
+    ]
 
 
 def _is_edge(obj: m.ModelElement) -> bool:
@@ -93,6 +112,14 @@ class CustomCollector:
             for edge_uuid, box_uuid in self.edge_owners.items():
                 if box := self.boxes.get(box_uuid):
                     box.edges.append(self.edges.pop(edge_uuid))
+
+        derivator = DERIVATORS.get(type(self.target))
+        if self.diagram._display_derived_interfaces and derivator is not None:
+            derivator(
+                self.diagram,
+                self.data,
+                self.boxes,
+            )
 
         self._fix_box_heights()
         for uuid in self.boxes_to_delete:
@@ -292,3 +319,84 @@ def collector(
 ) -> _elkjs.ELKInputData:
     """Collect data for rendering a custom diagram."""
     return CustomCollector(diagram, params)()
+
+
+def derive_from_functions(
+    diagram: context.CustomDiagram,
+    data: _elkjs.ELKInputData,
+    boxes: dict[str, _elkjs.ELKInputChild],
+) -> None:
+    """Derive Components from allocated functions of the context target.
+
+    A Component, a ComponentExchange and two ComponentPorts are added
+    to ``data``. These elements are prefixed with ``Derived-`` to
+    receive special styling in the serialization step.
+    """
+    assert isinstance(diagram.target, cs.Component)
+    ports: list[m.ModelElement] = []
+    for fnc in diagram.target.allocated_functions:
+        inc, out = default.port_collector(fnc, diagram.type)
+        ports.extend((inc | out).values())
+
+    derived_components: dict[str, cs.Component] = {}
+    for port in ports:
+        for fex in port.exchanges:
+            if isinstance(port, fa.FunctionOutputPort):
+                attr = "target"
+            else:
+                attr = "source"
+
+            try:
+                derived_comp = getattr(fex, attr).owner.owner
+                if (
+                    derived_comp == diagram.target
+                    or derived_comp.uuid in boxes
+                ):
+                    continue
+
+                if derived_comp.uuid not in derived_components:
+                    derived_components[derived_comp.uuid] = derived_comp
+            except AttributeError:  # No owner of owner.
+                pass
+
+    # Idea: Include flow direction of derived interfaces from all functional
+    # exchanges. Mixed means bidirectional. Just even out bidirectional
+    # interfaces and keep flow direction of others.
+
+    centerbox = boxes[diagram.target.uuid]
+    i = 0
+    for i, (uuid, derived_component) in enumerate(
+        derived_components.items(), 1
+    ):
+        box = makers.make_box(
+            derived_component,
+            no_symbol=diagram._display_symbols_as_boxes,
+        )
+        class_ = diagram.serializer.get_styleclass(derived_component.uuid)
+        box.id = f"{makers.STYLECLASS_PREFIX}-{class_}:{uuid}"
+        data.children.append(box)
+        source_id = f"{makers.STYLECLASS_PREFIX}-CP_INOUT:{i}"
+        target_id = f"{makers.STYLECLASS_PREFIX}-CP_INOUT:{-i}"
+        box.ports.append(makers.make_port(source_id))
+        centerbox.ports.append(makers.make_port(target_id))
+        if i % 2 == 0:
+            source_id, target_id = target_id, source_id
+
+        data.edges.append(
+            _elkjs.ELKInputEdge(
+                id=f"{makers.STYLECLASS_PREFIX}-ComponentExchange:{i}",
+                sources=[source_id],
+                targets=[target_id],
+            )
+        )
+
+    centerbox.height += (
+        makers.PORT_PADDING + (makers.PORT_SIZE + makers.PORT_PADDING) * i // 2
+    )
+
+
+DERIVATORS: dict[type[m.ModelElement], DerivatorFunction] = {
+    la.LogicalComponent: derive_from_functions,
+    sa.SystemComponent: derive_from_functions,
+}
+"""Supported objects to build derived contexts for."""

--- a/src/capellambse_context_diagrams/collectors/custom.py
+++ b/src/capellambse_context_diagrams/collectors/custom.py
@@ -13,7 +13,7 @@ import capellambse.model as m
 from capellambse.metamodel import cs, fa, la, sa
 
 from .. import _elkjs, context
-from . import default, generic, makers
+from . import generic, makers
 
 if t.TYPE_CHECKING:
     from .. import context
@@ -391,7 +391,7 @@ def derive_from_functions(
     assert isinstance(diagram.target, cs.Component)
     ports: list[m.ModelElement] = []
     for fnc in diagram.target.allocated_functions:
-        inc, out = default.port_collector(fnc, diagram.type)
+        inc, out = generic.port_collector(fnc, diagram.type)
         ports.extend((inc | out).values())
 
     derived_components: dict[str, cs.Component] = {}

--- a/src/capellambse_context_diagrams/collectors/dataflow_view.py
+++ b/src/capellambse_context_diagrams/collectors/dataflow_view.py
@@ -14,14 +14,14 @@ import capellambse.model as m
 from capellambse.metamodel import fa, oa
 
 from .. import _elkjs, context
-from . import default, generic, makers, portless
+from . import generic, makers, portless
 
 COLLECTOR_PARAMS: dict[m.DiagramType, dict[str, t.Any]] = {
     m.DiagramType.OAIB: {"attribute": "involved_activities"},
     m.DiagramType.SDFB: {
         "attribute": "involved_functions",
         "filter_attrs": ("source.owner", "target.owner"),
-        "port_collector": default.port_collector,
+        "port_collector": generic.port_collector,
     },
 }
 
@@ -90,7 +90,7 @@ def _collect_data(
         data.children.append(box := makers.make_box(elem))
         if port_collector:
             _ports = port_collector(elem, diagram.type)
-            connections = default.port_exchange_collector(
+            connections = generic.port_exchange_collector(
                 _ports, filter=filter
             )
             edges = list(chain.from_iterable(connections.values()))

--- a/src/capellambse_context_diagrams/collectors/default.py
+++ b/src/capellambse_context_diagrams/collectors/default.py
@@ -54,8 +54,9 @@ def collector(
             elif ex.target.uuid in ports and ex.source.uuid not in ports:
                 outside_components[ex.source.owner.uuid] = ex.source.owner
 
-        for cmp in list(getattr(target, "components", [])):
-            yield from _collect(cmp)
+        if diagram._include_children_context or diagram._blackbox:
+            for cmp in list(getattr(target, "components", [])):
+                yield from _collect(cmp)
 
     def _collect_extended_context(
         target: m.ModelElement,
@@ -76,6 +77,4 @@ def collector(
             )
 
     diagram._collect = _collect_extended_context(diagram.target)
-    processor = custom.CustomCollector(diagram, params=params)
-    processor()
-    return processor.data
+    return custom.CustomCollector(diagram, params=params)()

--- a/src/capellambse_context_diagrams/collectors/default.py
+++ b/src/capellambse_context_diagrams/collectors/default.py
@@ -61,6 +61,8 @@ def collector(
         target: m.ModelElement,
     ) -> cabc.Iterator[m.ModelElement]:
         yield from _collect(target)
+        if not diagram._display_actor_relation:
+            return
         oc_copy = outside_components.copy()
         for cmp in oc_copy.values():
             yield from _collect(
@@ -73,10 +75,7 @@ def collector(
                 ),
             )
 
-    if diagram._display_actor_relationship:
-        diagram._collect = _collect(diagram.target)
-    else:
-        diagram._collect = _collect_extended_context(diagram.target)
+    diagram._collect = _collect_extended_context(diagram.target)
     processor = custom.CustomCollector(diagram, params=params)
     processor()
     return processor.data

--- a/src/capellambse_context_diagrams/collectors/default.py
+++ b/src/capellambse_context_diagrams/collectors/default.py
@@ -14,8 +14,6 @@ import typing as t
 from itertools import chain
 
 import capellambse.model as m
-from capellambse.metamodel import cs, fa
-from capellambse.model import DiagramType as DT
 
 from .. import _elkjs
 from . import custom, generic
@@ -44,8 +42,10 @@ def collector(
             return
         visited.add(target.uuid)
 
-        inc, out = port_collector(target, diagram.type)
-        ports = port_exchange_collector((inc | out).values(), filter=filter)
+        inc, out = generic.port_collector(target, diagram.type)
+        ports = generic.port_exchange_collector(
+            (inc | out).values(), filter=filter
+        )
         exchanges = chain.from_iterable(ports.values())
         for ex in exchanges:
             yield ex
@@ -79,84 +79,3 @@ def collector(
     processor = custom.CustomCollector(diagram, params=params)
     processor()
     return processor.data
-
-
-def port_collector(
-    target: m.ModelElement | m.ElementList, diagram_type: DT
-) -> tuple[dict[str, m.ModelElement], dict[str, m.ModelElement]]:
-    """Collect ports from `target` savely."""
-
-    def __collect(target):
-        port_types = fa.FunctionPort | fa.ComponentPort | cs.PhysicalPort
-        incoming_ports: dict[str, m.ModelElement] = {}
-        outgoing_ports: dict[str, m.ModelElement] = {}
-        for attr in generic.DIAGRAM_TYPE_TO_CONNECTOR_NAMES[diagram_type]:
-            try:
-                ports = getattr(target, attr)
-                if not ports or not isinstance(ports[0], port_types):
-                    continue
-
-                if attr == "inputs":
-                    incoming_ports.update({p.uuid: p for p in ports})
-                elif attr == "ports":
-                    for port in ports:
-                        if port.direction == "IN":
-                            incoming_ports[port.uuid] = port
-                        else:
-                            outgoing_ports[port.uuid] = port
-                else:
-                    outgoing_ports.update({p.uuid: p for p in ports})
-            except AttributeError:
-                pass
-        return incoming_ports, outgoing_ports
-
-    if isinstance(target, cabc.Iterable):
-        assert not isinstance(target, m.ModelElement)
-        incoming_ports: dict[str, m.ModelElement] = {}
-        outgoing_ports: dict[str, m.ModelElement] = {}
-        for obj in target:
-            inc, out = __collect(obj)
-            incoming_ports.update(inc)
-            outgoing_ports.update(out)
-    else:
-        incoming_ports, outgoing_ports = __collect(target)
-    return incoming_ports, outgoing_ports
-
-
-def _extract_edges(
-    obj: m.ModelElement,
-    attribute: str,
-    filter: Filter,
-) -> cabc.Iterable[m.ModelElement]:
-    return filter(getattr(obj, attribute, []))
-
-
-def port_exchange_collector(
-    ports: t.Iterable[m.ModelElement],
-    filter: Filter = lambda i: i,
-) -> dict[str, list[fa.AbstractExchange]]:
-    """Collect exchanges from `ports` savely."""
-    edges: dict[str, list[fa.AbstractExchange]] = {}
-
-    for port in ports:
-        if exs := _extract_edges(port, "exchanges", filter):
-            edges[port.uuid] = t.cast(list[fa.AbstractExchange], exs)
-            continue
-
-        if links := _extract_edges(port, "links", filter):
-            edges[port.uuid] = t.cast(list[fa.AbstractExchange], links)
-
-    return edges
-
-
-class ContextInfo(t.NamedTuple):
-    """ContextInfo data."""
-
-    element: m.ModelElement
-    """An element of context."""
-    ports: list[m.ModelElement]
-    """The context element's relevant ports.
-
-    This list only contains ports that at least one of the exchanges
-    passed into ``collect_exchanges`` sees.
-    """

--- a/src/capellambse_context_diagrams/collectors/default.py
+++ b/src/capellambse_context_diagrams/collectors/default.py
@@ -11,15 +11,13 @@ from __future__ import annotations
 
 import collections.abc as cabc
 import typing as t
-from itertools import chain
 
 import capellambse.model as m
-from capellambse import helpers
 from capellambse.metamodel import cs, fa, la, sa
 from capellambse.model import DiagramType as DT
 
 from .. import _elkjs
-from . import exchanges, generic, makers
+from . import custom, generic, makers
 
 if t.TYPE_CHECKING:
     from .. import context
@@ -39,281 +37,46 @@ if t.TYPE_CHECKING:
     ]
 
 
-class ContextProcessor:
-    def __init__(
-        self,
-        diagram: context.ContextDiagram,
-        data: _elkjs.ELKInputData,
-        *,
-        params: dict[str, t.Any] | None = None,
-    ) -> None:
-        self.diagram = diagram
-        self.data = data
-        self.params = params or {}
-        self.centerbox = self.data.children[0]
-        self.global_boxes = {self.centerbox.id: self.centerbox}
-        self.made_boxes = {self.centerbox.id: self.centerbox}
-        self.boxes_to_delete = {self.centerbox.id}
-        self.exchanges: dict[str, fa.AbstractExchange] = {}
-        if self.diagram._display_parent_relation:
-            self.diagram_target_owners = list(
-                generic.get_all_owners(self.diagram.target)
-            )
-            self.common_owners: set[str] = set()
-
-    def process_context(self):
-        if (
-            self.diagram._display_parent_relation
-            and getattr(self.diagram.target, "owner", None) is not None
-            and not isinstance(self.diagram.target.owner, generic.PackageTypes)
-        ):
-            box = self._make_box(
-                self.diagram.target.owner,
-                layout_options=makers.DEFAULT_LABEL_LAYOUT_OPTIONS,
-            )
-            box.children = [self.centerbox]
-            del self.data.children[0]
-
-        self._process_ports()
-
-        if self.diagram._display_parent_relation and self.diagram.target.owner:
-            current = self.diagram.target.owner
-            while (
-                current
-                and self.common_owners
-                and hasattr(current, "owner")
-                and not isinstance(current.owner, generic.PackageTypes)
-            ):
-                current = generic.make_owner_box(
-                    current,
-                    self._make_box,
-                    self.global_boxes,
-                    self.boxes_to_delete,
-                )
-                self.common_owners.discard(current.uuid)
-
-        for uuid in self.boxes_to_delete:
-            del self.global_boxes[uuid]
-
-        self.data.children.extend(self.global_boxes.values())
-        if self.diagram._display_parent_relation:
-            generic.move_parent_boxes_to_owner(
-                self.made_boxes, self.diagram.target, self.data
-            )
-            generic.move_edges(
-                self.made_boxes, self.exchanges.values(), self.data
-            )
-
-        if self.diagram._hide_direct_children:
-            self.centerbox.children = []
-            hidden = {edge.id for edge in self.centerbox.edges}
-            centerbox_ports = {port.id for port in self.centerbox.ports}
-            port_uuids: set[str] = set()
-            for ex in self.exchanges.values():
-                if ex.uuid not in hidden:
-                    if ex.source.uuid in centerbox_ports:
-                        port_uuids.add(ex.source.uuid)
-                    if ex.target.uuid in centerbox_ports:
-                        port_uuids.add(ex.target.uuid)
-
-            self.centerbox.edges = []
-            self.centerbox.ports = [
-                p for p in self.centerbox.ports if p.id in port_uuids
-            ]
-            for label in self.centerbox.labels:
-                label.layoutOptions = makers.CENTRIC_LABEL_LAYOUT_OPTIONS
-
-    def _process_port_spread(
-        self,
-        exs: list[fa.AbstractExchange],
-        attr: str,
-        inc: int,
-        port_spread: dict[str, int],
-        owners: dict[str, str],
-    ) -> None:
-        for ex in exs:
-            elem = getattr(ex, attr).owner
-            if (owner := owners.get(elem.uuid)) is None:
-                try:
-                    owner = [
-                        uuid
-                        for uuid in generic.get_all_owners(elem)
-                        if uuid not in self.diagram_target_owners
-                    ][-1]
-                except (IndexError, AttributeError):
-                    owner = elem.uuid
-                assert owner is not None
-                owners[elem.uuid] = owner
-            port_spread.setdefault(owner, 0)
-            port_spread[owner] += inc
-
-    def _process_exchanges(
-        self,
-    ) -> tuple[
-        list[m.ModelElement],
-        list[generic.ExchangeData],
-    ]:
-        inc, out = port_collector(self.diagram.target, self.diagram.type)
-        inc_c = port_exchange_collector(inc.values())
-        out_c = port_exchange_collector(out.values())
-        inc_exchanges = list(chain.from_iterable(inc_c.values()))
-        out_exchanges = list(chain.from_iterable(out_c.values()))
-        port_spread: dict[str, int] = {}
-        owners: dict[str, str] = {}
-        self._process_port_spread(
-            inc_exchanges, "source", 1, port_spread, owners
-        )
-        self._process_port_spread(
-            out_exchanges, "target", -1, port_spread, owners
-        )
-        self.exchanges = {ex.uuid: ex for ex in inc_exchanges + out_exchanges}
-        ex_datas: list[generic.ExchangeData] = []
-        seen_exchanges: set[str] = set()
-        for ex in self.exchanges.values():
-            if ex.uuid in seen_exchanges:
-                continue
-
-            seen_exchanges.add(ex.uuid)
-            if is_hierarchical := exchanges.is_hierarchical(
-                ex, self.centerbox
-            ):
-                if not self.diagram._display_parent_relation:
-                    continue
-                self.centerbox.labels[
-                    0
-                ].layoutOptions = makers.DEFAULT_LABEL_LAYOUT_OPTIONS
-                elkdata: _elkjs.ELKInputData = self.centerbox
-            else:
-                elkdata = self.data
-            try:
-                ex_data = generic.ExchangeData(
-                    ex,
-                    elkdata,
-                    self.diagram.filters,
-                    self.params,
-                    is_hierarchical,
-                )
-                src, tgt = generic.exchange_data_collector(ex_data)
-                src_owner = owners.get(src.owner.uuid, "")
-                tgt_owner = owners.get(tgt.owner.uuid, "")
-                is_inc = tgt.parent == self.diagram.target
-                is_out = src.parent == self.diagram.target
-                if is_inc and is_out:
-                    pass  # Support cycles
-                elif (is_out and (port_spread.get(tgt_owner, 0) > 0)) or (
-                    is_inc and (port_spread.get(src_owner, 0) <= 0)
-                ):
-                    elkdata.edges[-1].sources = [tgt.uuid]
-                    elkdata.edges[-1].targets = [src.uuid]
-                ex_datas.append(ex_data)
-            except AttributeError:
-                continue
-
-        ports = list((inc | out).values())
-        if not self.diagram._display_unused_ports:
-            ports = [
-                p for p in ports if (inc_c.get(p.uuid) or out_c.get(p.uuid))
-            ]
-
-        self.centerbox.height = max(
-            self.centerbox.height,
-            (makers.PORT_SIZE + 2 * makers.PORT_PADDING) * (len(ports) + 1),
-        )
-        for p in ports:
-            port, height = self._make_port(p)
-            self.centerbox.height += height
-
-            self.centerbox.ports.append(port)
-        self.centerbox.layoutOptions["portLabels.placement"] = "OUTSIDE"
-
-        return ports, ex_datas
-
-    def _process_ports(self) -> None:
-        ports, ex_datas = self._process_exchanges()
-        for owner, local_ports in port_context_collector(ex_datas, ports):
-            _, label_height = helpers.get_text_extent(owner.name)
-            height = max(
-                label_height + 2 * makers.LABEL_VPAD,
-                (makers.PORT_SIZE + 2 * makers.PORT_PADDING)
-                * (len(local_ports) + 1),
-            )
-            local_port_objs = []
-            for j in local_ports:
-                port, label_heights = self._make_port(j)
-                height += label_heights
-                local_port_objs.append(port)
-
-            if box := self.global_boxes.get(owner.uuid):
-                if box is self.centerbox:
-                    continue
-                box.ports.extend(local_port_objs)
-                box.height += height
-            else:
-                box = self._make_box(
-                    owner,
-                    height=height,
-                )
-                box.ports = local_port_objs
-
-            box.layoutOptions["portLabels.placement"] = "OUTSIDE"
-
-            if self.diagram._display_parent_relation:
-                self.common_owners.add(
-                    generic.make_owner_boxes(
-                        owner,
-                        self.diagram_target_owners,
-                        self._make_box,
-                        self.global_boxes,
-                        self.boxes_to_delete,
-                    )
-                )
-
-    def _make_port(
-        self, port_obj: t.Any
-    ) -> tuple[_elkjs.ELKInputPort, int | float]:
-        port = makers.make_port(port_obj.uuid)
-        height = 0.0
-        if self.diagram._display_port_labels:
-            port.labels = makers.make_label(port_obj.name)
-            height += max(
-                0,
-                sum(label.height for label in port.labels)
-                - 2 * makers.PORT_PADDING,
-            )
-        return port, height
-
-    def _make_box(
-        self,
-        obj: t.Any,
-        **kwargs: t.Any,
-    ) -> _elkjs.ELKInputChild:
-        if box := self.global_boxes.get(obj.uuid):
-            return box
-        box = makers.make_box(
-            obj,
-            no_symbol=self.diagram._display_symbols_as_boxes,
-            **kwargs,
-        )
-        self.global_boxes[obj.uuid] = box
-        self.made_boxes[obj.uuid] = box
-        return box
-
-
 def collector(
-    diagram: context.ContextDiagram, params: dict[str, t.Any] | None = None
+    diagram: context.ContextDiagram, params: dict[str, t.Any]
 ) -> _elkjs.ELKInputData:
     """Collect context data from ports of centric box."""
-    data = generic.collector(diagram, no_symbol=True)
-    processor = ContextProcessor(diagram, data, params=params)
-    processor.process_context()
+    visited: set[str] = set()
+    edges: set[str] = set()
+
+    def _default_collect(
+        target: m.ModelElement,
+    ) -> cabc.Iterator[m.ModelElement]:
+        if target.uuid in visited:
+            return
+        visited.add(target.uuid)
+        for port in (
+            list(getattr(target, "inputs", []))
+            + list(getattr(target, "outputs", []))
+            + list(getattr(target, "ports", []))
+            + list(getattr(target, "physical_ports", []))
+        ):
+            for exchange in list(getattr(port, "exchanges", [])) + list(
+                getattr(port, "links", [])
+            ):
+                if exchange.uuid in edges:
+                    continue
+                edges.add(exchange.uuid)
+                yield exchange
+        for cmp in list(getattr(target, "components", [])):
+            yield from _default_collect(cmp)
+
+    diagram._collect = _default_collect(diagram.target)
+    processor = custom.CustomCollector(diagram, params=params)
+    processor()
     derivator = DERIVATORS.get(type(diagram.target))
     if diagram._display_derived_interfaces and derivator is not None:
         derivator(
             diagram,
-            data,
-            processor.made_boxes,
+            processor.data,
+            processor.boxes,
         )
-    return data
+    return processor.data
 
 
 def port_collector(
@@ -395,55 +158,6 @@ class ContextInfo(t.NamedTuple):
     This list only contains ports that at least one of the exchanges
     passed into ``collect_exchanges`` sees.
     """
-
-
-def port_context_collector(
-    exchange_datas: t.Iterable[generic.ExchangeData],
-    local_ports: t.Container[m.ModelElement],
-) -> t.Iterator[ContextInfo]:
-    """Collect the context objects.
-
-    Parameters
-    ----------
-    exchange_datas
-        The ``ExchangeData``s to look at to find new elements.
-    local_ports
-        Connectors/Ports lookup where ``exchange_datas`` is checked
-        against. If an exchange connects via a port from ``local_ports``
-        it is collected.
-
-    Returns
-    -------
-    contexts
-        An iterator over
-        [`ContextDiagram.ContextInfo`s][capellambse_context_diagrams.context.ContextDiagram].
-    """
-
-    ctx: dict[str, ContextInfo] = {}
-    for exd in exchange_datas:
-        try:
-            source, target = generic.collect_exchange_endpoints(exd)
-        except AttributeError:
-            continue
-
-        if source in local_ports:
-            port = target
-        elif target in local_ports:
-            port = source
-        else:
-            continue
-
-        try:
-            owner = port.owner
-        except AttributeError:
-            continue
-
-        info = ContextInfo(owner, [])
-        info = ctx.setdefault(owner.uuid, info)
-        if port not in info.ports:
-            info.ports.append(port)
-
-    return iter(ctx.values())
 
 
 def derive_from_functions(

--- a/src/capellambse_context_diagrams/collectors/default.py
+++ b/src/capellambse_context_diagrams/collectors/default.py
@@ -73,7 +73,10 @@ def collector(
                 ),
             )
 
-    diagram._collect = _collect_extended_context(diagram.target)
+    if diagram._display_actor_relationship:
+        diagram._collect = _collect(diagram.target)
+    else:
+        diagram._collect = _collect_extended_context(diagram.target)
     processor = custom.CustomCollector(diagram, params=params)
     processor()
     return processor.data

--- a/src/capellambse_context_diagrams/collectors/generic.py
+++ b/src/capellambse_context_diagrams/collectors/generic.py
@@ -14,11 +14,17 @@ import logging
 import typing as t
 
 import capellambse.model as m
-from capellambse.metamodel import interaction, la, oa, pa, sa
+from capellambse.metamodel import cs, fa, interaction, la, oa, pa, sa
 from capellambse.model import DiagramType as DT
 
 from .. import _elkjs, context, filters
 from . import makers
+
+if t.TYPE_CHECKING:
+    Filter: t.TypeAlias = cabc.Callable[
+        [cabc.Iterable[m.ModelElement]],
+        cabc.Iterable[m.ModelElement],
+    ]
 
 logger = logging.getLogger(__name__)
 
@@ -314,3 +320,71 @@ def make_owner_boxes(
             current, make_box_func, boxes, boxes_to_delete
         )
     return current.uuid
+
+
+def port_collector(
+    target: m.ModelElement | m.ElementList, diagram_type: DT
+) -> tuple[dict[str, m.ModelElement], dict[str, m.ModelElement]]:
+    """Collect ports from `target` savely."""
+
+    def __collect(target):
+        port_types = fa.FunctionPort | fa.ComponentPort | cs.PhysicalPort
+        incoming_ports: dict[str, m.ModelElement] = {}
+        outgoing_ports: dict[str, m.ModelElement] = {}
+        for attr in DIAGRAM_TYPE_TO_CONNECTOR_NAMES[diagram_type]:
+            try:
+                ports = getattr(target, attr)
+                if not ports or not isinstance(ports[0], port_types):
+                    continue
+
+                if attr == "inputs":
+                    incoming_ports.update({p.uuid: p for p in ports})
+                elif attr == "ports":
+                    for port in ports:
+                        if port.direction == "IN":
+                            incoming_ports[port.uuid] = port
+                        else:
+                            outgoing_ports[port.uuid] = port
+                else:
+                    outgoing_ports.update({p.uuid: p for p in ports})
+            except AttributeError:
+                pass
+        return incoming_ports, outgoing_ports
+
+    if isinstance(target, cabc.Iterable):
+        assert not isinstance(target, m.ModelElement)
+        incoming_ports: dict[str, m.ModelElement] = {}
+        outgoing_ports: dict[str, m.ModelElement] = {}
+        for obj in target:
+            inc, out = __collect(obj)
+            incoming_ports.update(inc)
+            outgoing_ports.update(out)
+    else:
+        incoming_ports, outgoing_ports = __collect(target)
+    return incoming_ports, outgoing_ports
+
+
+def _extract_edges(
+    obj: m.ModelElement,
+    attribute: str,
+    filter: Filter,
+) -> cabc.Iterable[m.ModelElement]:
+    return filter(getattr(obj, attribute, []))
+
+
+def port_exchange_collector(
+    ports: t.Iterable[m.ModelElement],
+    filter: Filter = lambda i: i,
+) -> dict[str, list[fa.AbstractExchange]]:
+    """Collect exchanges from `ports` savely."""
+    edges: dict[str, list[fa.AbstractExchange]] = {}
+
+    for port in ports:
+        if exs := _extract_edges(port, "exchanges", filter):
+            edges[port.uuid] = t.cast(list[fa.AbstractExchange], exs)
+            continue
+
+        if links := _extract_edges(port, "links", filter):
+            edges[port.uuid] = t.cast(list[fa.AbstractExchange], links)
+
+    return edges

--- a/src/capellambse_context_diagrams/collectors/makers.py
+++ b/src/capellambse_context_diagrams/collectors/makers.py
@@ -72,8 +72,8 @@ SYMBOL_LAYOUT_OPTIONS: _elkjs.LayoutOptions = {
 STYLECLASS_PREFIX = "__Derived"
 
 
-def make_diagram(diagram: context.ContextDiagram) -> _elkjs.ELKInputData:
-    """Return basic skeleton for ``ContextDiagram``s."""
+def make_diagram(diagram: context.CustomDiagram) -> _elkjs.ELKInputData:
+    """Return basic skeleton for ``CustomDiagram``s."""
     return _elkjs.ELKInputData(
         id=diagram.uuid,
         layoutOptions=_elkjs.get_global_layered_layout_options(),

--- a/src/capellambse_context_diagrams/context.py
+++ b/src/capellambse_context_diagrams/context.py
@@ -288,7 +288,7 @@ class CustomDiagram(m.AbstractDiagram):
     * collect - A list of collected elements.
     * unify_edge_direction - Unify the direction of the edges.
     * balckbox - Display the object of interest as a black box.
-    * display_actor_relationship: Show the connections between the context actors.
+    * display_actor_relation: Show the connections between the context actors.
     """
 
     _display_symbols_as_boxes: bool
@@ -302,7 +302,7 @@ class CustomDiagram(m.AbstractDiagram):
     _collect: cabc.Iterator[m.ModelElement]
     _unify_edge_direction: str
     _blackbox: bool
-    _display_actor_relationship: bool
+    _display_actor_relation: bool
 
     def __init__(
         self,
@@ -333,7 +333,7 @@ class CustomDiagram(m.AbstractDiagram):
             "collect": [],
             "unify_edge_direction": "NONE",
             "blackbox": False,
-            "display_actor_relationship": False,
+            "display_actor_relation": False,
         } | default_render_parameters
 
         if standard_filter := STANDARD_FILTERS.get(class_):
@@ -464,7 +464,6 @@ class ContextDiagram(CustomDiagram):
         default_render_parameters = {
             "slim_center_box": True,
             "unify_edge_direction": "SMART",
-            "blackbox": True,
         } | default_render_parameters
 
         super().__init__(

--- a/src/capellambse_context_diagrams/context.py
+++ b/src/capellambse_context_diagrams/context.py
@@ -289,6 +289,7 @@ class CustomDiagram(m.AbstractDiagram):
     * unify_edge_direction - Unify the direction of the edges.
     * balckbox - Display the object of interest as a black box.
     * display_actor_relation: Show the connections between the context actors.
+    * include_children_context: Include all children of the object of interest.
     """
 
     _display_symbols_as_boxes: bool
@@ -303,6 +304,7 @@ class CustomDiagram(m.AbstractDiagram):
     _unify_edge_direction: str
     _blackbox: bool
     _display_actor_relation: bool
+    _include_children_context: bool
 
     def __init__(
         self,
@@ -334,6 +336,7 @@ class CustomDiagram(m.AbstractDiagram):
             "unify_edge_direction": "NONE",
             "blackbox": False,
             "display_actor_relation": False,
+            "include_children_context": False,
         } | default_render_parameters
 
         if standard_filter := STANDARD_FILTERS.get(class_):
@@ -464,6 +467,7 @@ class ContextDiagram(CustomDiagram):
         default_render_parameters = {
             "slim_center_box": True,
             "unify_edge_direction": "SMART",
+            "include_children_context": True,
         } | default_render_parameters
 
         super().__init__(

--- a/src/capellambse_context_diagrams/context.py
+++ b/src/capellambse_context_diagrams/context.py
@@ -288,6 +288,7 @@ class CustomDiagram(m.AbstractDiagram):
     * collect - A list of collected elements.
     * unify_edge_direction - Unify the direction of the edges.
     * balckbox - Display the object of interest as a black box.
+    * display_actor_relationship: Show the connections between the context actors.
     """
 
     _display_symbols_as_boxes: bool
@@ -301,6 +302,7 @@ class CustomDiagram(m.AbstractDiagram):
     _collect: cabc.Iterator[m.ModelElement]
     _unify_edge_direction: str
     _blackbox: bool
+    _display_actor_relationship: bool
 
     def __init__(
         self,
@@ -331,6 +333,7 @@ class CustomDiagram(m.AbstractDiagram):
             "collect": [],
             "unify_edge_direction": "NONE",
             "blackbox": False,
+            "display_actor_relationship": False,
         } | default_render_parameters
 
         if standard_filter := STANDARD_FILTERS.get(class_):

--- a/src/capellambse_context_diagrams/context.py
+++ b/src/capellambse_context_diagrams/context.py
@@ -950,7 +950,7 @@ class PhysicalPortContextDiagram(ContextDiagram):
         default_render_parameters = {
             "collect": _collector(obj),
             "display_parent_relation": True,
-            "unify_edge_direction": "UNIFORM",
+            "unify_edge_direction": "TREE",
             "display_port_labels": True,
             "port_label_position": _elkjs.PORT_LABEL_POSITION.OUTSIDE.name,
         } | default_render_parameters

--- a/src/capellambse_context_diagrams/context.py
+++ b/src/capellambse_context_diagrams/context.py
@@ -283,16 +283,15 @@ class CustomDiagram(m.AbstractDiagram):
     * display_port_labels — Display port labels on the diagram.
     * port_label_position - Position of the port labels. See
       [`PORT_LABEL_POSITION`][capellambse_context_diagrams.context._elkjs.PORT_LABEL_POSITION].
-    * hide_direct_children - Hide direct children of the object of
-      interest.
+
     * display_unused_ports - Display ports that are not connected to an edge.
     * collect - A list of collected elements.
     * unify_edge_direction - Unify the direction of the edges.
+    * balckbox - Display the object of interest as a black box.
     """
 
     _display_symbols_as_boxes: bool
     _display_parent_relation: bool
-    _hide_direct_children: bool
     _display_derived_interfaces: bool
     _slim_center_box: bool
     _display_port_labels: bool
@@ -301,6 +300,7 @@ class CustomDiagram(m.AbstractDiagram):
     _display_unused_ports: bool
     _collect: cabc.Iterator[m.ModelElement]
     _unify_edge_direction: str
+    _blackbox: bool
 
     def __init__(
         self,
@@ -322,7 +322,6 @@ class CustomDiagram(m.AbstractDiagram):
         self._default_render_parameters = {
             "display_symbols_as_boxes": False,
             "display_parent_relation": False,
-            "hide_direct_children": False,
             "display_derived_interfaces": False,
             "slim_center_box": False,
             "display_port_labels": False,
@@ -331,6 +330,7 @@ class CustomDiagram(m.AbstractDiagram):
             "transparent_background": False,
             "collect": [],
             "unify_edge_direction": "NONE",
+            "blackbox": False,
         } | default_render_parameters
 
         if standard_filter := STANDARD_FILTERS.get(class_):
@@ -461,6 +461,7 @@ class ContextDiagram(CustomDiagram):
         default_render_parameters = {
             "slim_center_box": True,
             "unify_edge_direction": "SMART",
+            "blackbox": True,
         } | default_render_parameters
 
         super().__init__(

--- a/src/capellambse_context_diagrams/context.py
+++ b/src/capellambse_context_diagrams/context.py
@@ -460,7 +460,7 @@ class ContextDiagram(CustomDiagram):
     ) -> None:
         default_render_parameters = {
             "slim_center_box": True,
-            "unify_edge_direction": "UNIFORM",
+            "unify_edge_direction": "SMART",
         } | default_render_parameters
 
         super().__init__(

--- a/src/capellambse_context_diagrams/serializers.py
+++ b/src/capellambse_context_diagrams/serializers.py
@@ -61,7 +61,7 @@ class DiagramSerializer:
 
     diagram: cdiagram.Diagram
 
-    def __init__(self, elk_diagram: context.ContextDiagram) -> None:
+    def __init__(self, elk_diagram: context.CustomDiagram) -> None:
         self.model = elk_diagram.target._model
         self._diagram = elk_diagram
         self._cache: dict[str, cdiagram.DiagramElement] = {}

--- a/tests/data/ContextDiagram.aird
+++ b/tests/data/ContextDiagram.aird
@@ -194,6 +194,14 @@
         <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']"/>
         <target xmi:type="org.polarsys.capella.core.data.la:LogicalComponentPkg" href="ContextDiagram.capella#84c0978d-9a32-4f5b-8013-5b0b6adbfd73"/>
       </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_VenLkNfmEe-M75BVrVuK-Q" name="[LAB] Blackbox" repPath="#_Vegd4NfmEe-M75BVrVuK-Q" changeId="6b10f31f-2ef1-4137-8619-be9465fcc5a7">
+        <eAnnotations xmi:type="description:DAnnotation" uid="_Veq18NfmEe-M75BVrVuK-Q" source="https://www.polarsys.org/capella/dannotation/DesactivatedFilters">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Veq18dfmEe-M75BVrVuK-Q" key="hide.computed.component.exchanges.filter" value="true"/>
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Veq18tfmEe-M75BVrVuK-Q" key="hide.computed.physical.links.filter" value="true"/>
+        </eAnnotations>
+        <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']"/>
+        <target xmi:type="org.polarsys.capella.core.data.la:LogicalComponentPkg" href="ContextDiagram.capella#84c0978d-9a32-4f5b-8013-5b0b6adbfd73"/>
+      </ownedRepresentationDescriptors>
     </ownedViews>
     <ownedViews xmi:type="viewpoint:DView" uid="_4Dt18PHWEeq9N-vcO9FSUw">
       <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.kitalpha.vp.requirements.design/description/Requirements.odesign#//@ownedViewpoints[name='Requirements_ID']"/>
@@ -17865,5 +17873,435 @@
     <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer"/>
     <activatedLayers xmi:type="description_1:AdditionalLayer" href="platform:/plugin/org.polarsys.capella.vp.requirements.design/description/CapellaRequirements.odesign#//@ownedViewpoints[name='CapellaRequirements_ID']/@ownedRepresentationExtensions[name='CapellaViewpoints']/@layers[name='ReqVP_Requirements_Layer']"/>
     <target xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponentPkg" href="ContextDiagram.capella#f7e20d0e-d219-4867-a287-5a56e2d9a63c"/>
+  </diagram:DSemanticDiagram>
+  <diagram:DSemanticDiagram uid="_Vegd4NfmEe-M75BVrVuK-Q">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_Vepn0NfmEe-M75BVrVuK-Q" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_Vepn0dfmEe-M75BVrVuK-Q" type="Sirius" element="_Vegd4NfmEe-M75BVrVuK-Q" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_XPTtINfmEe-M75BVrVuK-Q" type="2002" element="_XOTAgNfmEe-M75BVrVuK-Q">
+          <children xmi:type="notation:Node" xmi:id="_XPTtI9fmEe-M75BVrVuK-Q" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_XPTtJNfmEe-M75BVrVuK-Q" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_cKd_kNfmEe-M75BVrVuK-Q" type="3008" element="_cJehENfmEe-M75BVrVuK-Q">
+              <children xmi:type="notation:Node" xmi:id="_cKd_k9fmEe-M75BVrVuK-Q" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_cKd_lNfmEe-M75BVrVuK-Q" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_cKemoNfmEe-M75BVrVuK-Q"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_cKemodfmEe-M75BVrVuK-Q"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_qsEn0NfmEe-M75BVrVuK-Q" type="3012" element="_qq0DkNfmEe-M75BVrVuK-Q">
+                <children xmi:type="notation:Node" xmi:id="_qsEn09fmEe-M75BVrVuK-Q" visible="false" type="5010">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_qsEn1NfmEe-M75BVrVuK-Q" y="11"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_qsEn1dfmEe-M75BVrVuK-Q" type="3005" element="_qq0DkdfmEe-M75BVrVuK-Q">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_qsEn1tfmEe-M75BVrVuK-Q" fontName="Sans"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qsEn19fmEe-M75BVrVuK-Q"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_qsEn0dfmEe-M75BVrVuK-Q" fontName="Sans" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qsEn0tfmEe-M75BVrVuK-Q" x="151" y="10" width="10" height="10"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_1wORwNfmEe-M75BVrVuK-Q" type="3012" element="_1vLI4NfmEe-M75BVrVuK-Q">
+                <children xmi:type="notation:Node" xmi:id="_1wO40NfmEe-M75BVrVuK-Q" visible="false" type="5010">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_1wO40dfmEe-M75BVrVuK-Q" x="11"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_1wO40tfmEe-M75BVrVuK-Q" type="3005" element="_1vLv8NfmEe-M75BVrVuK-Q">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_1wO409fmEe-M75BVrVuK-Q" fontName="Sans"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1wO41NfmEe-M75BVrVuK-Q"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_1wORwdfmEe-M75BVrVuK-Q" fontName="Sans" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1wORwtfmEe-M75BVrVuK-Q" x="90" y="21" width="10" height="10"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_cKd_kdfmEe-M75BVrVuK-Q" fontName="Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cKd_ktfmEe-M75BVrVuK-Q" x="45" y="54" width="161" height="31"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_gZhZ8NfmEe-M75BVrVuK-Q" type="3008" element="_gYcb4NfmEe-M75BVrVuK-Q">
+              <children xmi:type="notation:Node" xmi:id="_gZiBANfmEe-M75BVrVuK-Q" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_gZiBAdfmEe-M75BVrVuK-Q" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_gZiBAtfmEe-M75BVrVuK-Q"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_gZiBA9fmEe-M75BVrVuK-Q"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_lnO08NfmEe-M75BVrVuK-Q" type="3012" element="_llGuANfmEe-M75BVrVuK-Q">
+                <children xmi:type="notation:Node" xmi:id="_lnPcANfmEe-M75BVrVuK-Q" visible="false" type="5010">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_lnPcAdfmEe-M75BVrVuK-Q" y="11"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_lnR4QNfmEe-M75BVrVuK-Q" type="3005" element="_llHVENfmEe-M75BVrVuK-Q">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_lnR4QdfmEe-M75BVrVuK-Q" fontName="Sans"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lnR4QtfmEe-M75BVrVuK-Q"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_lnO08dfmEe-M75BVrVuK-Q" fontName="Sans" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lnO08tfmEe-M75BVrVuK-Q" x="-2" y="30" width="10" height="10"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_1wPf4NfmEe-M75BVrVuK-Q" type="3012" element="_1vMXANfmEe-M75BVrVuK-Q">
+                <children xmi:type="notation:Node" xmi:id="_1wQG8NfmEe-M75BVrVuK-Q" visible="false" type="5010">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_1wQG8dfmEe-M75BVrVuK-Q" x="11"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_1wQuANfmEe-M75BVrVuK-Q" type="3005" element="_1vMXAdfmEe-M75BVrVuK-Q">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_1wQuAdfmEe-M75BVrVuK-Q" fontName="Sans"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1wQuAtfmEe-M75BVrVuK-Q"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_1wPf4dfmEe-M75BVrVuK-Q" fontName="Sans" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1wPf4tfmEe-M75BVrVuK-Q" x="70" y="-2" width="10" height="10"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_gZhZ8dfmEe-M75BVrVuK-Q" fontName="Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gZhZ8tfmEe-M75BVrVuK-Q" x="65" y="164"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_XPTtJdfmEe-M75BVrVuK-Q"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_XPTtJtfmEe-M75BVrVuK-Q"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_qsDZsNfmEe-M75BVrVuK-Q" type="3012" element="_qq0qodfmEe-M75BVrVuK-Q">
+            <children xmi:type="notation:Node" xmi:id="_qsEAwNfmEe-M75BVrVuK-Q" visible="false" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_qsEAwdfmEe-M75BVrVuK-Q" y="11"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_qsFO4NfmEe-M75BVrVuK-Q" type="3005" element="_qq1RsNfmEe-M75BVrVuK-Q">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_qsFO4dfmEe-M75BVrVuK-Q" fontName="Sans"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qsFO4tfmEe-M75BVrVuK-Q"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_qsDZsdfmEe-M75BVrVuK-Q" fontName="Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qsDZstfmEe-M75BVrVuK-Q" x="261" y="70" width="10" height="10"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_XPTtIdfmEe-M75BVrVuK-Q" fontName="Sans" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XPTtItfmEe-M75BVrVuK-Q" x="430" y="150" width="271" height="341"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_Z-VfMNfmEe-M75BVrVuK-Q" type="2002" element="_Z9g_0NfmEe-M75BVrVuK-Q">
+          <children xmi:type="notation:Node" xmi:id="_Z-WGQNfmEe-M75BVrVuK-Q" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_Z-WGQdfmEe-M75BVrVuK-Q" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_Z-WGQtfmEe-M75BVrVuK-Q"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_Z-WGQ9fmEe-M75BVrVuK-Q"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_lnSfUNfmEe-M75BVrVuK-Q" type="3012" element="_llFf4NfmEe-M75BVrVuK-Q">
+            <children xmi:type="notation:Node" xmi:id="_lnSfU9fmEe-M75BVrVuK-Q" visible="false" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_lnSfVNfmEe-M75BVrVuK-Q" x="11"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_lnTGYNfmEe-M75BVrVuK-Q" type="3005" element="_llFf4dfmEe-M75BVrVuK-Q">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_lnTGYdfmEe-M75BVrVuK-Q" fontName="Sans"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lnTGYtfmEe-M75BVrVuK-Q"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_lnSfUdfmEe-M75BVrVuK-Q" fontName="Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lnSfUtfmEe-M75BVrVuK-Q" x="140" y="30" width="10" height="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_yRKw8NfmEe-M75BVrVuK-Q" type="3012" element="_yP2iUNfmEe-M75BVrVuK-Q">
+            <children xmi:type="notation:Node" xmi:id="_yRLYANfmEe-M75BVrVuK-Q" visible="false" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_yRLYAdfmEe-M75BVrVuK-Q" x="11"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_yRLYAtfmEe-M75BVrVuK-Q" type="3005" element="_yP3JYNfmEe-M75BVrVuK-Q">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_yRLYA9fmEe-M75BVrVuK-Q" fontName="Sans"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yRLYBNfmEe-M75BVrVuK-Q"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_yRKw8dfmEe-M75BVrVuK-Q" fontName="Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yRKw8tfmEe-M75BVrVuK-Q" x="90" y="60" width="10" height="10"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_Z-VfMdfmEe-M75BVrVuK-Q" fontName="Sans" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Z-VfMtfmEe-M75BVrVuK-Q" x="120" y="330"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_iTPUoNfmEe-M75BVrVuK-Q" type="2002" element="_iSS5cNfmEe-M75BVrVuK-Q">
+          <children xmi:type="notation:Node" xmi:id="_iTPUo9fmEe-M75BVrVuK-Q" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_iTPUpNfmEe-M75BVrVuK-Q" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_iTPUpdfmEe-M75BVrVuK-Q"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_iTPUptfmEe-M75BVrVuK-Q"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_tBFXYNfmEe-M75BVrVuK-Q" type="3012" element="_s_8H4NfmEe-M75BVrVuK-Q">
+            <children xmi:type="notation:Node" xmi:id="_tBF-cNfmEe-M75BVrVuK-Q" visible="false" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_tBF-cdfmEe-M75BVrVuK-Q" y="11"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_tBGlgNfmEe-M75BVrVuK-Q" type="3005" element="_s_8H4dfmEe-M75BVrVuK-Q">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_tBGlgdfmEe-M75BVrVuK-Q" fontName="Sans"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tBGlgtfmEe-M75BVrVuK-Q"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_tBFXYdfmEe-M75BVrVuK-Q" fontName="Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tBFXYtfmEe-M75BVrVuK-Q" x="-2" y="50" width="10" height="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_yRL_ENfmEe-M75BVrVuK-Q" type="3012" element="_yP3wcNfmEe-M75BVrVuK-Q">
+            <children xmi:type="notation:Node" xmi:id="_yRL_E9fmEe-M75BVrVuK-Q" visible="false" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_yRL_FNfmEe-M75BVrVuK-Q" x="11"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_yRMmINfmEe-M75BVrVuK-Q" type="3005" element="_yP3wcdfmEe-M75BVrVuK-Q">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_yRMmIdfmEe-M75BVrVuK-Q" fontName="Sans"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yRMmItfmEe-M75BVrVuK-Q"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_yRL_EdfmEe-M75BVrVuK-Q" fontName="Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yRL_EtfmEe-M75BVrVuK-Q" x="80" y="60" width="10" height="10"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_iTPUodfmEe-M75BVrVuK-Q" fontName="Sans" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iTPUotfmEe-M75BVrVuK-Q" x="810" y="190"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_Vepn0tfmEe-M75BVrVuK-Q"/>
+        <edges xmi:type="notation:Edge" xmi:id="_lnTGY9fmEe-M75BVrVuK-Q" type="4001" element="_llIjMNfmEe-M75BVrVuK-Q" source="_lnSfUNfmEe-M75BVrVuK-Q" target="_lnO08NfmEe-M75BVrVuK-Q">
+          <children xmi:type="notation:Node" xmi:id="_lnTtcNfmEe-M75BVrVuK-Q" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lnTtcdfmEe-M75BVrVuK-Q" x="1" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_lnTtctfmEe-M75BVrVuK-Q" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lnTtc9fmEe-M75BVrVuK-Q" x="-4" y="8"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_lnTtdNfmEe-M75BVrVuK-Q" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lnTtddfmEe-M75BVrVuK-Q" x="-4" y="8"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_lnTGZNfmEe-M75BVrVuK-Q" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_lnTGZdfmEe-M75BVrVuK-Q" fontColor="9914954" fontName="Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lnTGZtfmEe-M75BVrVuK-Q" points="[5, -1, -233, 9]$[233, -10, -5, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lnTtdtfmEe-M75BVrVuK-Q" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lnTtd9fmEe-M75BVrVuK-Q" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_qsFO49fmEe-M75BVrVuK-Q" type="4001" element="_qq14wNfmEe-M75BVrVuK-Q" source="_qsEn0NfmEe-M75BVrVuK-Q" target="_qsDZsNfmEe-M75BVrVuK-Q">
+          <children xmi:type="notation:Node" xmi:id="_qsF18NfmEe-M75BVrVuK-Q" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qsF18dfmEe-M75BVrVuK-Q" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_qsF18tfmEe-M75BVrVuK-Q" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qsF189fmEe-M75BVrVuK-Q" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_qsF19NfmEe-M75BVrVuK-Q" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qsF19dfmEe-M75BVrVuK-Q" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_qsFO5NfmEe-M75BVrVuK-Q" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_qsFO5dfmEe-M75BVrVuK-Q" fontColor="9914954" fontName="Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qsFO5tfmEe-M75BVrVuK-Q" points="[5, 0, -60, -6]$[60, 5, -5, -1]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qsF19tfmEe-M75BVrVuK-Q" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qsF199fmEe-M75BVrVuK-Q" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_tBHMkNfmEe-M75BVrVuK-Q" type="4001" element="_s_99ENfmEe-M75BVrVuK-Q" source="_tBFXYNfmEe-M75BVrVuK-Q" target="_qsDZsNfmEe-M75BVrVuK-Q">
+          <children xmi:type="notation:Node" xmi:id="_tBHMlNfmEe-M75BVrVuK-Q" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tBHMldfmEe-M75BVrVuK-Q" x="6" y="-6"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_tBHMltfmEe-M75BVrVuK-Q" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tBHMl9fmEe-M75BVrVuK-Q" x="-1" y="9"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_tBHMmNfmEe-M75BVrVuK-Q" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tBHMmdfmEe-M75BVrVuK-Q" x="-1" y="9"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_tBHMkdfmEe-M75BVrVuK-Q" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_tBHMktfmEe-M75BVrVuK-Q" fontColor="9914954" fontName="Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tBHMk9fmEe-M75BVrVuK-Q" points="[0, 0, 107, 25]$[-107, -25, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tBHMmtfmEe-M75BVrVuK-Q" id="(0.0,0.5882352941176471)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tBHMm9fmEe-M75BVrVuK-Q" id="(1.0,0.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_yRNNMNfmEe-M75BVrVuK-Q" type="4001" element="_yP4XgdfmEe-M75BVrVuK-Q" source="_yRKw8NfmEe-M75BVrVuK-Q" target="_yRL_ENfmEe-M75BVrVuK-Q">
+          <children xmi:type="notation:Node" xmi:id="_yRNNNNfmEe-M75BVrVuK-Q" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yRNNNdfmEe-M75BVrVuK-Q" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_yRNNNtfmEe-M75BVrVuK-Q" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yRNNN9fmEe-M75BVrVuK-Q" x="7" y="7"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_yRNNONfmEe-M75BVrVuK-Q" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yRNNOdfmEe-M75BVrVuK-Q" x="-3" y="1"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_yRNNMdfmEe-M75BVrVuK-Q" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_yRNNMtfmEe-M75BVrVuK-Q" fontColor="9914954" fontName="Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yRNNM9fmEe-M75BVrVuK-Q" points="[4, 4, -676, 144]$[155, 165, -525, 305]$[645, 165, -35, 305]$[679, -136, -1, 4]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yRN0QNfmEe-M75BVrVuK-Q" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yRN0QdfmEe-M75BVrVuK-Q" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_1wRVENfmEe-M75BVrVuK-Q" type="4001" element="_1vM-EdfmEe-M75BVrVuK-Q" source="_1wORwNfmEe-M75BVrVuK-Q" target="_1wPf4NfmEe-M75BVrVuK-Q">
+          <children xmi:type="notation:Node" xmi:id="_1wRVFNfmEe-M75BVrVuK-Q" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1wRVFdfmEe-M75BVrVuK-Q" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_1wRVFtfmEe-M75BVrVuK-Q" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1wRVF9fmEe-M75BVrVuK-Q" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_1wRVGNfmEe-M75BVrVuK-Q" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1wRVGdfmEe-M75BVrVuK-Q" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_1wRVEdfmEe-M75BVrVuK-Q" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_1wRVEtfmEe-M75BVrVuK-Q" fontColor="9914954" fontName="Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1wRVE9fmEe-M75BVrVuK-Q" points="[0, 5, 0, -82]$[0, 82, 0, -5]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1wRVGtfmEe-M75BVrVuK-Q" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1wRVG9fmEe-M75BVrVuK-Q" id="(0.5,0.5)"/>
+        </edges>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_VfTvINfmEe-M75BVrVuK-Q" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_VfTvIdfmEe-M75BVrVuK-Q"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_XOTAgNfmEe-M75BVrVuK-Q" name="Parent LC">
+      <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#64f28085-f6dc-4141-8864-47c195423f04"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#64f28085-f6dc-4141-8864-47c195423f04"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalComponent" href="ContextDiagram.capella#77b3349c-9184-478a-b005-893a4d789b47"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_qq0qodfmEe-M75BVrVuK-Q" name="CP 3" incomingEdges="_qq14wNfmEe-M75BVrVuK-Q _s_99ENfmEe-M75BVrVuK-Q" width="1" height="1">
+        <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#4b0f396a-0f77-4675-a702-3575d67f6e05"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#4b0f396a-0f77-4675-a702-3575d67f6e05"/>
+        <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_qq1RstfmEe-M75BVrVuK-Q"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_qq1RsNfmEe-M75BVrVuK-Q" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/InFlowPort.png">
+          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.1/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_XOTnkNfmEe-M75BVrVuK-Q" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="195,230,255" foregroundColor="150,177,218">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_cJehENfmEe-M75BVrVuK-Q" name="Child LC 1">
+        <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#22881485-4989-49c0-8068-5af004d1db63"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#22881485-4989-49c0-8068-5af004d1db63"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalComponent" href="ContextDiagram.capella#5694dff8-0645-4155-b836-7736a89f5c39"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_qq0DkNfmEe-M75BVrVuK-Q" name="CP 1" outgoingEdges="_qq14wNfmEe-M75BVrVuK-Q" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#138c1c84-713d-4567-9304-30364330b5a9"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#138c1c84-713d-4567-9304-30364330b5a9"/>
+          <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_qq0qoNfmEe-M75BVrVuK-Q"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_qq0DkdfmEe-M75BVrVuK-Q" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/OutFlowPort.png">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.2/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_1vLI4NfmEe-M75BVrVuK-Q" name="CP 2" outgoingEdges="_1vM-EdfmEe-M75BVrVuK-Q" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#386f8111-bd45-4bd0-a22b-b8f6c4b1216a"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#386f8111-bd45-4bd0-a22b-b8f6c4b1216a"/>
+          <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_1vLv8tfmEe-M75BVrVuK-Q"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_1vLv8NfmEe-M75BVrVuK-Q" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/OutFlowPort.png">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.2/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_cJfIINfmEe-M75BVrVuK-Q" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="195,230,255" foregroundColor="150,177,218">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']"/>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_gYcb4NfmEe-M75BVrVuK-Q" name="Child LC 2">
+        <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#47cc117b-3760-470b-9474-0472d149d194"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#47cc117b-3760-470b-9474-0472d149d194"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalComponent" href="ContextDiagram.capella#6a9d5145-d41d-4a28-a4fe-eb98b6f3da39"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_llGuANfmEe-M75BVrVuK-Q" name="CP 1" incomingEdges="_llIjMNfmEe-M75BVrVuK-Q" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#5da72784-c5fe-4283-8832-218ecc1c6526"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#5da72784-c5fe-4283-8832-218ecc1c6526"/>
+          <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_llHVEtfmEe-M75BVrVuK-Q"/>
+          <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+          <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+          <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_llHVENfmEe-M75BVrVuK-Q" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/InFlowPort.png">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.1/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_1vMXANfmEe-M75BVrVuK-Q" name="CP 2" incomingEdges="_1vM-EdfmEe-M75BVrVuK-Q" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#a662d5a2-beb0-469b-b947-f663ecf8f482"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#a662d5a2-beb0-469b-b947-f663ecf8f482"/>
+          <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_1vM-ENfmEe-M75BVrVuK-Q"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_1vMXAdfmEe-M75BVrVuK-Q" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/InFlowPort.png">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.1/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_gYcb4dfmEe-M75BVrVuK-Q" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="195,230,255" foregroundColor="150,177,218">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']"/>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_Z9g_0NfmEe-M75BVrVuK-Q" name="Left LC">
+      <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#4e1f6130-335b-4e4b-87fa-91f31d72b927"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#4e1f6130-335b-4e4b-87fa-91f31d72b927"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalComponent" href="ContextDiagram.capella#d2eec5a9-1de4-44f5-bd99-60bab004f00c"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_llFf4NfmEe-M75BVrVuK-Q" name="CP 1" outgoingEdges="_llIjMNfmEe-M75BVrVuK-Q" width="1" height="1">
+        <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#b24e2673-493c-4f43-9e37-619b35ac5452"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#b24e2673-493c-4f43-9e37-619b35ac5452"/>
+        <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_llGG8dfmEe-M75BVrVuK-Q"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_llFf4dfmEe-M75BVrVuK-Q" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/OutFlowPort.png">
+          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.2/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
+      </ownedBorderedNodes>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_yP2iUNfmEe-M75BVrVuK-Q" name="CP 2" outgoingEdges="_yP4XgdfmEe-M75BVrVuK-Q" width="1" height="1">
+        <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#ed788945-9729-4d56-a1fa-0554bee65324"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#ed788945-9729-4d56-a1fa-0554bee65324"/>
+        <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_yP3JYtfmEe-M75BVrVuK-Q"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_yP3JYNfmEe-M75BVrVuK-Q" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/OutFlowPort.png">
+          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.2/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
+      </ownedBorderedNodes>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_Z9g_0dfmEe-M75BVrVuK-Q" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="195,230,255" foregroundColor="150,177,218">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_iSS5cNfmEe-M75BVrVuK-Q" name="Right LC">
+      <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#a939c41a-e8ca-4823-b317-775451b1817c"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#a939c41a-e8ca-4823-b317-775451b1817c"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalComponent" href="ContextDiagram.capella#65622f9e-21af-4030-986e-bd4096e4f313"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_s_8H4NfmEe-M75BVrVuK-Q" name="CP 1" outgoingEdges="_s_99ENfmEe-M75BVrVuK-Q" width="1" height="1">
+        <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#34e4c983-e70a-424d-9ce4-858bd92cb925"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#34e4c983-e70a-424d-9ce4-858bd92cb925"/>
+        <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_s_8u8dfmEe-M75BVrVuK-Q"/>
+        <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+        <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+        <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_s_8H4dfmEe-M75BVrVuK-Q" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/OutFlowPort.png">
+          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.2/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
+      </ownedBorderedNodes>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_yP3wcNfmEe-M75BVrVuK-Q" name="CP 2" incomingEdges="_yP4XgdfmEe-M75BVrVuK-Q" width="1" height="1">
+        <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#4f903b92-1748-42ff-be33-a95472e20d13"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#4f903b92-1748-42ff-be33-a95472e20d13"/>
+        <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_yP4XgNfmEe-M75BVrVuK-Q"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_yP3wcdfmEe-M75BVrVuK-Q" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/InFlowPort.png">
+          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.1/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
+      </ownedBorderedNodes>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_iSTggNfmEe-M75BVrVuK-Q" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="195,230,255" foregroundColor="150,177,218">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_llIjMNfmEe-M75BVrVuK-Q" name="Left to LC 2" sourceNode="_llFf4NfmEe-M75BVrVuK-Q" targetNode="_llGuANfmEe-M75BVrVuK-Q">
+      <target xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#68212e30-0dcc-4b5f-83f2-0062f1feb1ba"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#68212e30-0dcc-4b5f-83f2-0062f1feb1ba"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_llJxUNfmEe-M75BVrVuK-Q" targetArrow="NoDecoration" centered="Both" strokeColor="74,74,151">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']/@conditionnalStyles.3/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_llJxUdfmEe-M75BVrVuK-Q" labelColor="74,74,151"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_qq14wNfmEe-M75BVrVuK-Q" name="Target to LC 1" sourceNode="_qq0DkNfmEe-M75BVrVuK-Q" targetNode="_qq0qodfmEe-M75BVrVuK-Q">
+      <target xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#f9897b61-602d-4c18-a72d-f4521e7c094f"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#f9897b61-602d-4c18-a72d-f4521e7c094f"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_qq14wdfmEe-M75BVrVuK-Q" targetArrow="NoDecoration" centered="Both" strokeColor="74,74,151">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']/@conditionnalStyles.3/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_qq14wtfmEe-M75BVrVuK-Q" labelColor="74,74,151"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_s_99ENfmEe-M75BVrVuK-Q" name="Right to Target" sourceNode="_s_8H4NfmEe-M75BVrVuK-Q" targetNode="_qq0qodfmEe-M75BVrVuK-Q">
+      <target xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#da4b0e27-8850-4358-97dd-90f4e032cf10"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#da4b0e27-8850-4358-97dd-90f4e032cf10"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_s_-kINfmEe-M75BVrVuK-Q" targetArrow="NoDecoration" centered="Both" strokeColor="74,74,151">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']/@conditionnalStyles.3/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_s_-kIdfmEe-M75BVrVuK-Q" labelColor="74,74,151"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_yP4XgdfmEe-M75BVrVuK-Q" name="outer extended" sourceNode="_yP2iUNfmEe-M75BVrVuK-Q" targetNode="_yP3wcNfmEe-M75BVrVuK-Q">
+      <target xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#58322776-25ab-42c7-93ee-44d37e8e7144"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#58322776-25ab-42c7-93ee-44d37e8e7144"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_yP4-kNfmEe-M75BVrVuK-Q" targetArrow="NoDecoration" centered="Both" strokeColor="74,74,151">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']/@conditionnalStyles.3/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_yP4-kdfmEe-M75BVrVuK-Q" labelColor="74,74,151"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_1vM-EdfmEe-M75BVrVuK-Q" name="inner extended" sourceNode="_1vLI4NfmEe-M75BVrVuK-Q" targetNode="_1vMXANfmEe-M75BVrVuK-Q">
+      <target xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#25f152df-7309-46d1-88ea-b34772c3eb34"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#25f152df-7309-46d1-88ea-b34772c3eb34"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_1vNlINfmEe-M75BVrVuK-Q" targetArrow="NoDecoration" centered="Both" strokeColor="74,74,151">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']/@conditionnalStyles.3/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_1vNlIdfmEe-M75BVrVuK-Q" labelColor="74,74,151"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']"/>
+    <currentConcern xmi:type="concern:ConcernDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@concerns/@ownedConcernDescriptions.0"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@filters[name='hide.simplified.group.of.component.exchanges.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@filters[name='hide.sequencing.information.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@filters[name='hide.overlappedphysical.paths.label.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@filters[name='hide.simplified.diagram.based.component.exchanges.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@filters[name='hide.overlappedfunctional.chains.label.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@filters[name='hide.simplified.oriented.grouped.component.exchanges.filter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_VehE8NfmEe-M75BVrVuK-Q"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer"/>
+    <activatedLayers xmi:type="description_1:AdditionalLayer" href="platform:/plugin/org.polarsys.capella.vp.requirements.design/description/CapellaRequirements.odesign#//@ownedViewpoints[name='CapellaRequirements_ID']/@ownedRepresentationExtensions[name='CapellaViewpoints']/@layers[name='ReqVP_Requirements_Layer']"/>
+    <target xmi:type="org.polarsys.capella.core.data.la:LogicalComponentPkg" href="ContextDiagram.capella#84c0978d-9a32-4f5b-8013-5b0b6adbfd73"/>
   </diagram:DSemanticDiagram>
 </xmi:XMI>

--- a/tests/data/ContextDiagram.aird
+++ b/tests/data/ContextDiagram.aird
@@ -202,6 +202,14 @@
         <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']"/>
         <target xmi:type="org.polarsys.capella.core.data.la:LogicalComponentPkg" href="ContextDiagram.capella#84c0978d-9a32-4f5b-8013-5b0b6adbfd73"/>
       </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_37lhkNigEe-Gv-xXZhqgNA" name="[LAB] Blackbox" repPath="#_37h3MNigEe-Gv-xXZhqgNA" changeId="a78648d0-ec48-42c2-8f88-bd982d4dbe4e">
+        <eAnnotations xmi:type="description:DAnnotation" uid="_37urgNigEe-Gv-xXZhqgNA" source="https://www.polarsys.org/capella/dannotation/DesactivatedFilters">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_37urgdigEe-Gv-xXZhqgNA" key="hide.computed.component.exchanges.filter" value="true"/>
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_37urgtigEe-Gv-xXZhqgNA" key="hide.computed.physical.links.filter" value="true"/>
+        </eAnnotations>
+        <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']"/>
+        <target xmi:type="org.polarsys.capella.core.data.la:LogicalComponentPkg" href="ContextDiagram.capella#84c0978d-9a32-4f5b-8013-5b0b6adbfd73"/>
+      </ownedRepresentationDescriptors>
     </ownedViews>
     <ownedViews xmi:type="viewpoint:DView" uid="_4Dt18PHWEeq9N-vcO9FSUw">
       <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.kitalpha.vp.requirements.design/description/Requirements.odesign#//@ownedViewpoints[name='Requirements_ID']"/>
@@ -18211,6 +18219,413 @@
     <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@filters[name='hide.simplified.group.of.component.exchanges.filter']"/>
     <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@filters[name='hide.simplified.oriented.grouped.component.exchanges.filter']"/>
     <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_WEhz0NP7Ee-ZFOhjqU8_vw"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer"/>
+    <activatedLayers xmi:type="description_1:AdditionalLayer" href="platform:/plugin/org.polarsys.capella.vp.requirements.design/description/CapellaRequirements.odesign#//@ownedViewpoints[name='CapellaRequirements_ID']/@ownedRepresentationExtensions[name='CapellaViewpoints']/@layers[name='ReqVP_Requirements_Layer']"/>
+    <target xmi:type="org.polarsys.capella.core.data.la:LogicalComponentPkg" href="ContextDiagram.capella#84c0978d-9a32-4f5b-8013-5b0b6adbfd73"/>
+  </diagram:DSemanticDiagram>
+  <diagram:DSemanticDiagram uid="_37h3MNigEe-Gv-xXZhqgNA">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_37tdYNigEe-Gv-xXZhqgNA" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_37tdYdigEe-Gv-xXZhqgNA" type="Sirius" element="_37h3MNigEe-Gv-xXZhqgNA" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_4qkugNigEe-Gv-xXZhqgNA" type="2002" element="_4pqIgNigEe-Gv-xXZhqgNA">
+          <children xmi:type="notation:Node" xmi:id="_4qmjsNigEe-Gv-xXZhqgNA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_4qnKwNigEe-Gv-xXZhqgNA" type="7001">
+            <children xmi:type="notation:Node" xmi:id="__5BSMNigEe-Gv-xXZhqgNA" type="3008" element="__3xVANigEe-Gv-xXZhqgNA">
+              <children xmi:type="notation:Node" xmi:id="__5BSM9igEe-Gv-xXZhqgNA" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="__5B5QNigEe-Gv-xXZhqgNA" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="__5B5QdigEe-Gv-xXZhqgNA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="__5B5QtigEe-Gv-xXZhqgNA"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_tpzTQNihEe-Gv-xXZhqgNA" type="3012" element="_tpApENihEe-Gv-xXZhqgNA">
+                <children xmi:type="notation:Node" xmi:id="_tpz6UNihEe-Gv-xXZhqgNA" visible="false" type="5010">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_tpz6UdihEe-Gv-xXZhqgNA" x="11"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_tp0hYNihEe-Gv-xXZhqgNA" type="3005" element="_tpApEdihEe-Gv-xXZhqgNA">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_tp0hYdihEe-Gv-xXZhqgNA" fontName="Sans"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tp0hYtihEe-Gv-xXZhqgNA"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_tpzTQdihEe-Gv-xXZhqgNA" fontName="Sans" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tpzTQtihEe-Gv-xXZhqgNA" x="140" y="30" width="10" height="10"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_3wJ4MNihEe-Gv-xXZhqgNA" type="3012" element="_3vWm8NihEe-Gv-xXZhqgNA">
+                <children xmi:type="notation:Node" xmi:id="_3wKfQNihEe-Gv-xXZhqgNA" visible="false" type="5010">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_3wKfQdihEe-Gv-xXZhqgNA" y="11"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_3wLGUNihEe-Gv-xXZhqgNA" type="3005" element="_3vWm8dihEe-Gv-xXZhqgNA">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_3wLGUdihEe-Gv-xXZhqgNA" fontName="Sans"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3wLGUtihEe-Gv-xXZhqgNA"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_3wJ4MdihEe-Gv-xXZhqgNA" fontName="Sans" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3wJ4MtihEe-Gv-xXZhqgNA" x="-2" y="30" width="10" height="10"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="__5BSMdigEe-Gv-xXZhqgNA" fontName="Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="__5BSMtigEe-Gv-xXZhqgNA" x="125" y="54"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_BN0h8NihEe-Gv-xXZhqgNA" type="3008" element="_BNGwQNihEe-Gv-xXZhqgNA">
+              <children xmi:type="notation:Node" xmi:id="_BN1JANihEe-Gv-xXZhqgNA" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_BN1JAdihEe-Gv-xXZhqgNA" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_BN1JAtihEe-Gv-xXZhqgNA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_BN1JA9ihEe-Gv-xXZhqgNA"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_xj3VENihEe-Gv-xXZhqgNA" type="3012" element="_xjHHINihEe-Gv-xXZhqgNA">
+                <children xmi:type="notation:Node" xmi:id="_xj38INihEe-Gv-xXZhqgNA" visible="false" type="5010">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_xj38IdihEe-Gv-xXZhqgNA" x="11"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_xj4jMNihEe-Gv-xXZhqgNA" type="3005" element="_xjHHIdihEe-Gv-xXZhqgNA">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_xj4jMdihEe-Gv-xXZhqgNA" fontName="Sans"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xj4jMtihEe-Gv-xXZhqgNA"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_xj3VEdihEe-Gv-xXZhqgNA" fontName="Sans" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xj3VEtihEe-Gv-xXZhqgNA" x="140" y="40" width="10" height="10"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_BN0h8dihEe-Gv-xXZhqgNA" fontName="Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BN0h8tihEe-Gv-xXZhqgNA" x="125" y="234"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_4qnKwdigEe-Gv-xXZhqgNA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_4qnKwtigEe-Gv-xXZhqgNA"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_pwQO0NihEe-Gv-xXZhqgNA" type="3012" element="_pvTMktihEe-Gv-xXZhqgNA">
+            <children xmi:type="notation:Node" xmi:id="_pwQO09ihEe-Gv-xXZhqgNA" visible="false" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_pwQO1NihEe-Gv-xXZhqgNA" y="11"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_pwQ14NihEe-Gv-xXZhqgNA" type="3005" element="_pvTzoNihEe-Gv-xXZhqgNA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_pwQ14dihEe-Gv-xXZhqgNA" fontName="Sans"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pwQ14tihEe-Gv-xXZhqgNA"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_pwQO0dihEe-Gv-xXZhqgNA" fontName="Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pwQO0tihEe-Gv-xXZhqgNA" x="-2" y="80" width="10" height="10"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_4qkugdigEe-Gv-xXZhqgNA" fontName="Sans" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4qkugtigEe-Gv-xXZhqgNA" x="370" y="140" width="303" height="363"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_FuURoNihEe-Gv-xXZhqgNA" type="2002" element="_FtlR0NihEe-Gv-xXZhqgNA">
+          <children xmi:type="notation:Node" xmi:id="_FuURo9ihEe-Gv-xXZhqgNA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_FuU4sNihEe-Gv-xXZhqgNA" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_KXdnANihEe-Gv-xXZhqgNA" type="3008" element="_KWv1UNihEe-Gv-xXZhqgNA">
+              <children xmi:type="notation:Node" xmi:id="_KXdnA9ihEe-Gv-xXZhqgNA" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_KXdnBNihEe-Gv-xXZhqgNA" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_KXdnBdihEe-Gv-xXZhqgNA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_KXdnBtihEe-Gv-xXZhqgNA"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_tp0hY9ihEe-Gv-xXZhqgNA" type="3012" element="_tpBQIdihEe-Gv-xXZhqgNA">
+                <children xmi:type="notation:Node" xmi:id="_tp0hZtihEe-Gv-xXZhqgNA" visible="false" type="5010">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_tp0hZ9ihEe-Gv-xXZhqgNA" y="11"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_tp1IcNihEe-Gv-xXZhqgNA" type="3005" element="_tpBQItihEe-Gv-xXZhqgNA">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_tp1IcdihEe-Gv-xXZhqgNA" fontName="Sans"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tp1IctihEe-Gv-xXZhqgNA"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_tp0hZNihEe-Gv-xXZhqgNA" fontName="Sans" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tp0hZdihEe-Gv-xXZhqgNA" x="-2" y="20" width="10" height="10"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_KXdnAdihEe-Gv-xXZhqgNA" fontName="Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KXdnAtihEe-Gv-xXZhqgNA" x="15" y="44"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_NYNbMNihEe-Gv-xXZhqgNA" type="3008" element="_NXjT4NihEe-Gv-xXZhqgNA">
+              <children xmi:type="notation:Node" xmi:id="_NYNbM9ihEe-Gv-xXZhqgNA" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_NYOCQNihEe-Gv-xXZhqgNA" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_NYOCQdihEe-Gv-xXZhqgNA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_NYOCQtihEe-Gv-xXZhqgNA"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_xj4jM9ihEe-Gv-xXZhqgNA" type="3012" element="_xjHuMtihEe-Gv-xXZhqgNA">
+                <children xmi:type="notation:Node" xmi:id="_xj5KQNihEe-Gv-xXZhqgNA" visible="false" type="5010">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_xj5KQdihEe-Gv-xXZhqgNA" y="11"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_xj5KQtihEe-Gv-xXZhqgNA" type="3005" element="_xjIVQNihEe-Gv-xXZhqgNA">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_xj5KQ9ihEe-Gv-xXZhqgNA" fontName="Sans"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xj5KRNihEe-Gv-xXZhqgNA"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_xj4jNNihEe-Gv-xXZhqgNA" fontName="Sans" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xj4jNdihEe-Gv-xXZhqgNA" x="-2" y="40" width="10" height="10"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_NYNbMdihEe-Gv-xXZhqgNA" fontName="Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NYNbMtihEe-Gv-xXZhqgNA" x="35" y="204"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_FuU4sdihEe-Gv-xXZhqgNA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_FuU4stihEe-Gv-xXZhqgNA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_FuURodihEe-Gv-xXZhqgNA" fontName="Sans" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FuURotihEe-Gv-xXZhqgNA" x="820" y="190" width="221" height="311"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_O0ZFUNihEe-Gv-xXZhqgNA" type="2002" element="_Ozo3YNihEe-Gv-xXZhqgNA">
+          <children xmi:type="notation:Node" xmi:id="_O0ZFU9ihEe-Gv-xXZhqgNA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_O0ZFVNihEe-Gv-xXZhqgNA" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_O0ZFVdihEe-Gv-xXZhqgNA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_O0ZFVtihEe-Gv-xXZhqgNA"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_pwQ149ihEe-Gv-xXZhqgNA" type="3012" element="_pvSlgNihEe-Gv-xXZhqgNA">
+            <children xmi:type="notation:Node" xmi:id="_pwQ15tihEe-Gv-xXZhqgNA" visible="false" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_pwQ159ihEe-Gv-xXZhqgNA" x="11"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_pwRc8NihEe-Gv-xXZhqgNA" type="3005" element="_pvSlgdihEe-Gv-xXZhqgNA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_pwRc8dihEe-Gv-xXZhqgNA" fontName="Sans"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pwRc8tihEe-Gv-xXZhqgNA"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_pwQ15NihEe-Gv-xXZhqgNA" fontName="Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pwQ15dihEe-Gv-xXZhqgNA" x="140" y="30" width="10" height="10"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_O0ZFUdihEe-Gv-xXZhqgNA" fontName="Sans" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_O0ZFUtihEe-Gv-xXZhqgNA" x="100" y="190"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_37tdYtigEe-Gv-xXZhqgNA"/>
+        <edges xmi:type="notation:Edge" xmi:id="_pwSEANihEe-Gv-xXZhqgNA" type="4001" element="_pvUasNihEe-Gv-xXZhqgNA" source="_pwQ149ihEe-Gv-xXZhqgNA" target="_pwQO0NihEe-Gv-xXZhqgNA">
+          <children xmi:type="notation:Node" xmi:id="_pwSEBNihEe-Gv-xXZhqgNA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pwSEBdihEe-Gv-xXZhqgNA" x="-2" y="-3"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_pwSEBtihEe-Gv-xXZhqgNA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pwSEB9ihEe-Gv-xXZhqgNA" x="9" y="2"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_pwSECNihEe-Gv-xXZhqgNA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pwSECdihEe-Gv-xXZhqgNA" x="-14" y="2"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_pwSEAdihEe-Gv-xXZhqgNA" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_pwSEAtihEe-Gv-xXZhqgNA" fontColor="9914954" fontName="Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pwSEA9ihEe-Gv-xXZhqgNA" points="[5, 0, -123, 0]$[123, 0, -5, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pwSrENihEe-Gv-xXZhqgNA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pwSrEdihEe-Gv-xXZhqgNA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_tp1vgNihEe-Gv-xXZhqgNA" type="4001" element="_tpB3MdihEe-Gv-xXZhqgNA" source="_tpzTQNihEe-Gv-xXZhqgNA" target="_tp0hY9ihEe-Gv-xXZhqgNA">
+          <children xmi:type="notation:Node" xmi:id="_tp1vhNihEe-Gv-xXZhqgNA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tp1vhdihEe-Gv-xXZhqgNA" x="-2" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_tp1vhtihEe-Gv-xXZhqgNA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tp1vh9ihEe-Gv-xXZhqgNA" x="-1" y="9"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_tp1viNihEe-Gv-xXZhqgNA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tp1vidihEe-Gv-xXZhqgNA" x="-1" y="7"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_tp1vgdihEe-Gv-xXZhqgNA" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_tp1vgtihEe-Gv-xXZhqgNA" fontColor="9914954" fontName="Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tp1vg9ihEe-Gv-xXZhqgNA" points="[5, 0, -193, -30]$[193, 29, -5, -1]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tp1vitihEe-Gv-xXZhqgNA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tp1vi9ihEe-Gv-xXZhqgNA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_xj5xUNihEe-Gv-xXZhqgNA" type="4001" element="_xjI8UNihEe-Gv-xXZhqgNA" source="_xj3VENihEe-Gv-xXZhqgNA" target="_xj4jM9ihEe-Gv-xXZhqgNA">
+          <children xmi:type="notation:Node" xmi:id="_xj5xVNihEe-Gv-xXZhqgNA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xj5xVdihEe-Gv-xXZhqgNA" x="-2" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_xj5xVtihEe-Gv-xXZhqgNA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xj5xV9ihEe-Gv-xXZhqgNA" x="-1" y="8"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_xj5xWNihEe-Gv-xXZhqgNA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xj5xWdihEe-Gv-xXZhqgNA" x="1" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_xj5xUdihEe-Gv-xXZhqgNA" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_xj5xUtihEe-Gv-xXZhqgNA" fontColor="9914954" fontName="Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xj5xU9ihEe-Gv-xXZhqgNA" points="[5, 0, -213, -20]$[213, 19, -5, -1]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xj6YYNihEe-Gv-xXZhqgNA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xj6YYdihEe-Gv-xXZhqgNA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_3wLtYNihEe-Gv-xXZhqgNA" type="4001" element="_3vX1ENihEe-Gv-xXZhqgNA" source="_3wJ4MNihEe-Gv-xXZhqgNA" target="_pwQO0NihEe-Gv-xXZhqgNA">
+          <children xmi:type="notation:Node" xmi:id="_3wLtZNihEe-Gv-xXZhqgNA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3wLtZdihEe-Gv-xXZhqgNA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_3wLtZtihEe-Gv-xXZhqgNA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3wLtZ9ihEe-Gv-xXZhqgNA" x="-1" y="11"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_3wLtaNihEe-Gv-xXZhqgNA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3wLtadihEe-Gv-xXZhqgNA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_3wLtYdihEe-Gv-xXZhqgNA" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_3wLtYtihEe-Gv-xXZhqgNA" fontColor="9914954" fontName="Sans" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3wLtY9ihEe-Gv-xXZhqgNA" points="[0, 0, 140, 8]$[-140, -8, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3wMUcNihEe-Gv-xXZhqgNA" id="(0.0,0.36764705882352944)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3wMUcdihEe-Gv-xXZhqgNA" id="(1.0,0.5)"/>
+        </edges>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_38PB0NigEe-Gv-xXZhqgNA" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_38PB0digEe-Gv-xXZhqgNA"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_4pqIgNigEe-Gv-xXZhqgNA" name="Parent LC">
+      <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#48210457-d83d-45d7-b663-28c44a79e0fa"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#48210457-d83d-45d7-b663-28c44a79e0fa"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalComponent" href="ContextDiagram.capella#fd69347c-fca9-4cdd-ae44-9182e13c8d9d"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_pvTMktihEe-Gv-xXZhqgNA" name="CP 3" incomingEdges="_pvUasNihEe-Gv-xXZhqgNA _3vX1ENihEe-Gv-xXZhqgNA" width="1" height="1">
+        <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#bcfc68d6-bce0-4281-9da5-eecd3ebc3025"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#bcfc68d6-bce0-4281-9da5-eecd3ebc3025"/>
+        <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_pvTzotihEe-Gv-xXZhqgNA"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_pvTzoNihEe-Gv-xXZhqgNA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/InFlowPort.png">
+          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.1/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_4prWoNigEe-Gv-xXZhqgNA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="195,230,255" foregroundColor="150,177,218">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="__3xVANigEe-Gv-xXZhqgNA" name="Child LC 1">
+        <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#78b12b60-f134-48e4-8440-53e1b2b115c5"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#78b12b60-f134-48e4-8440-53e1b2b115c5"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalComponent" href="ContextDiagram.capella#9f92e453-0692-4842-9e0c-4d36ab541acd"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_tpApENihEe-Gv-xXZhqgNA" name="CP 1" outgoingEdges="_tpB3MdihEe-Gv-xXZhqgNA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#3f2c5aeb-6351-458f-a581-a5eaa0e2b07f"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#3f2c5aeb-6351-458f-a581-a5eaa0e2b07f"/>
+          <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_tpBQINihEe-Gv-xXZhqgNA"/>
+          <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+          <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+          <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_tpApEdihEe-Gv-xXZhqgNA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/OutFlowPort.png">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.2/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_3vWm8NihEe-Gv-xXZhqgNA" name="CP 2" outgoingEdges="_3vX1ENihEe-Gv-xXZhqgNA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#ce221886-adfd-45f5-99cf-07baac99458d"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#ce221886-adfd-45f5-99cf-07baac99458d"/>
+          <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_3vXOAdihEe-Gv-xXZhqgNA"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_3vWm8dihEe-Gv-xXZhqgNA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/OutFlowPort.png">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.2/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
+        </ownedBorderedNodes>
+        <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+        <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+        <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="__3xVAdigEe-Gv-xXZhqgNA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="195,230,255" foregroundColor="150,177,218">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']"/>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_BNGwQNihEe-Gv-xXZhqgNA" name="Child LC 2">
+        <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#05f8fd0d-8fae-4d6d-b0d3-77428963d5c7"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#05f8fd0d-8fae-4d6d-b0d3-77428963d5c7"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalComponent" href="ContextDiagram.capella#847991cf-546d-4817-b52f-a58b5a42d0e5"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_xjHHINihEe-Gv-xXZhqgNA" name="CP 1" outgoingEdges="_xjI8UNihEe-Gv-xXZhqgNA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#5fcfacff-479d-4ac0-a832-56396a07c1fe"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#5fcfacff-479d-4ac0-a832-56396a07c1fe"/>
+          <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_xjHuMdihEe-Gv-xXZhqgNA"/>
+          <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+          <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+          <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_xjHHIdihEe-Gv-xXZhqgNA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/OutFlowPort.png">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.2/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
+        </ownedBorderedNodes>
+        <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+        <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+        <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_BNGwQdihEe-Gv-xXZhqgNA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="195,230,255" foregroundColor="150,177,218">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']"/>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_FtlR0NihEe-Gv-xXZhqgNA" name="Right LC">
+      <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#debfa8e3-da1a-445f-b6c8-7d2ac5b5aeaf"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#debfa8e3-da1a-445f-b6c8-7d2ac5b5aeaf"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalComponent" href="ContextDiagram.capella#b0a3a955-698f-4e66-8e71-599aa686290d"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_Ftl44NihEe-Gv-xXZhqgNA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="195,230,255" foregroundColor="150,177,218">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_KWv1UNihEe-Gv-xXZhqgNA" name="Right LC 1">
+        <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#a059ee90-c181-4d9c-9705-a7cc40704242"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#a059ee90-c181-4d9c-9705-a7cc40704242"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalComponent" href="ContextDiagram.capella#fdbed138-965e-4abd-82f6-1dc794970fde"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_tpBQIdihEe-Gv-xXZhqgNA" name="CP 1" incomingEdges="_tpB3MdihEe-Gv-xXZhqgNA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#6afd0810-6274-4bac-8092-d59a9ef9bd99"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#6afd0810-6274-4bac-8092-d59a9ef9bd99"/>
+          <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_tpB3MNihEe-Gv-xXZhqgNA"/>
+          <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+          <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+          <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_tpBQItihEe-Gv-xXZhqgNA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/InFlowPort.png">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.1/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_KWv1UdihEe-Gv-xXZhqgNA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="195,230,255" foregroundColor="150,177,218">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']"/>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_NXjT4NihEe-Gv-xXZhqgNA" name="Right LC 2">
+        <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#e2f83407-575c-42a1-8d82-7924ac0fb1f5"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#e2f83407-575c-42a1-8d82-7924ac0fb1f5"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalComponent" href="ContextDiagram.capella#7fa21226-c6d0-418c-a061-cb38b207b852"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_xjHuMtihEe-Gv-xXZhqgNA" name="CP 1" incomingEdges="_xjI8UNihEe-Gv-xXZhqgNA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#93f2fe63-cb60-4640-a1ab-d078b560a241"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#93f2fe63-cb60-4640-a1ab-d078b560a241"/>
+          <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_xjIVQtihEe-Gv-xXZhqgNA"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_xjIVQNihEe-Gv-xXZhqgNA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/InFlowPort.png">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.1/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_NXj68NihEe-Gv-xXZhqgNA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="195,230,255" foregroundColor="150,177,218">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']"/>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_Ozo3YNihEe-Gv-xXZhqgNA" name="Left LC">
+      <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#04dcd5d0-2521-4d19-978a-443f63969a9c"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#04dcd5d0-2521-4d19-978a-443f63969a9c"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalComponent" href="ContextDiagram.capella#9f7682b0-e830-4dd6-912b-0feb19ae0968"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_pvSlgNihEe-Gv-xXZhqgNA" name="CP 1" outgoingEdges="_pvUasNihEe-Gv-xXZhqgNA" width="1" height="1">
+        <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#79780935-a7b3-4c2c-b664-67a9b2ce0d82"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#79780935-a7b3-4c2c-b664-67a9b2ce0d82"/>
+        <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_pvTMkdihEe-Gv-xXZhqgNA"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_pvSlgdihEe-Gv-xXZhqgNA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/OutFlowPort.png">
+          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.2/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
+      </ownedBorderedNodes>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_Ozo3YdihEe-Gv-xXZhqgNA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="195,230,255" foregroundColor="150,177,218">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_pvUasNihEe-Gv-xXZhqgNA" name="Left to Parent" sourceNode="_pvSlgNihEe-Gv-xXZhqgNA" targetNode="_pvTMktihEe-Gv-xXZhqgNA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#453903da-1cbd-4bb8-bab2-d83a825ee7d1"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#453903da-1cbd-4bb8-bab2-d83a825ee7d1"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_pvUasdihEe-Gv-xXZhqgNA" targetArrow="NoDecoration" centered="Both" strokeColor="74,74,151">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']/@conditionnalStyles.3/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_pvUastihEe-Gv-xXZhqgNA" labelColor="74,74,151"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_tpB3MdihEe-Gv-xXZhqgNA" name="Child 1 to Right 1" sourceNode="_tpApENihEe-Gv-xXZhqgNA" targetNode="_tpBQIdihEe-Gv-xXZhqgNA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#d89b2b08-0061-4b43-9bd6-af829f80aa2f"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#d89b2b08-0061-4b43-9bd6-af829f80aa2f"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_tpCeQNihEe-Gv-xXZhqgNA" targetArrow="NoDecoration" centered="Both" strokeColor="74,74,151">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']/@conditionnalStyles.3/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_tpCeQdihEe-Gv-xXZhqgNA" labelColor="74,74,151"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_xjI8UNihEe-Gv-xXZhqgNA" name="Child 2 to Right 2" sourceNode="_xjHHINihEe-Gv-xXZhqgNA" targetNode="_xjHuMtihEe-Gv-xXZhqgNA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#6ba4f3d9-6adb-4632-817e-23d86b9b0637"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#6ba4f3d9-6adb-4632-817e-23d86b9b0637"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_xjI8UdihEe-Gv-xXZhqgNA" targetArrow="NoDecoration" centered="Both" strokeColor="74,74,151">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']/@conditionnalStyles.3/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_xjI8UtihEe-Gv-xXZhqgNA" labelColor="74,74,151"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_3vX1ENihEe-Gv-xXZhqgNA" name="Parent to Child 1" sourceNode="_3vWm8NihEe-Gv-xXZhqgNA" targetNode="_pvTMktihEe-Gv-xXZhqgNA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#955b6e5d-df64-4805-8973-93756a4be879"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#955b6e5d-df64-4805-8973-93756a4be879"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_3vX1EdihEe-Gv-xXZhqgNA" targetArrow="NoDecoration" centered="Both" strokeColor="74,74,151">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']/@conditionnalStyles.3/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_3vX1EtihEe-Gv-xXZhqgNA" labelColor="74,74,151"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']"/>
+    <currentConcern xmi:type="concern:ConcernDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@concerns/@ownedConcernDescriptions.0"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@filters[name='hide.simplified.diagram.based.component.exchanges.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@filters[name='hide.simplified.oriented.grouped.component.exchanges.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@filters[name='hide.sequencing.information.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@filters[name='hide.overlappedphysical.paths.label.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@filters[name='hide.simplified.group.of.component.exchanges.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@filters[name='hide.overlappedfunctional.chains.label.filter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_37ieQNigEe-Gv-xXZhqgNA"/>
     <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer"/>
     <activatedLayers xmi:type="description_1:AdditionalLayer" href="platform:/plugin/org.polarsys.capella.vp.requirements.design/description/CapellaRequirements.odesign#//@ownedViewpoints[name='CapellaRequirements_ID']/@ownedRepresentationExtensions[name='CapellaViewpoints']/@layers[name='ReqVP_Requirements_Layer']"/>
     <target xmi:type="org.polarsys.capella.core.data.la:LogicalComponentPkg" href="ContextDiagram.capella#84c0978d-9a32-4f5b-8013-5b0b6adbfd73"/>

--- a/tests/data/ContextDiagram.aird
+++ b/tests/data/ContextDiagram.aird
@@ -110,7 +110,7 @@
         <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']"/>
         <target xmi:type="org.polarsys.capella.core.data.la:LogicalComponentPkg" href="ContextDiagram.capella#84c0978d-9a32-4f5b-8013-5b0b6adbfd73"/>
       </ownedRepresentationDescriptors>
-      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_TmNTgB4sEe2oAusR2-iOGg" name="[LAB] Stacking" repPath="#_TmJCEB4sEe2oAusR2-iOGg" changeId="b3b22071-05e8-4cd5-92e5-27c49f0a898f">
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_TmNTgB4sEe2oAusR2-iOGg" name="[LAB] Stacking" repPath="#_TmJCEB4sEe2oAusR2-iOGg" changeId="75c9735c-2682-433b-b857-03d934e60551">
         <eAnnotations xmi:type="description:DAnnotation" uid="_TmQ94B4sEe2oAusR2-iOGg" source="https://www.polarsys.org/capella/dannotation/DesactivatedFilters">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_TmQ94R4sEe2oAusR2-iOGg" key="hide.computed.component.exchanges.filter" value="true"/>
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_TmQ94h4sEe2oAusR2-iOGg" key="hide.computed.physical.links.filter" value="true"/>
@@ -4831,6 +4831,17 @@
             <styles xmi:type="notation:ShapeStyle" xmi:id="_adBIYR4uEe2oAusR2-iOGg" fontName="Fira Code" fontHeight="8"/>
             <layoutConstraint xmi:type="notation:Bounds" xmi:id="_adBIYh4uEe2oAusR2-iOGg" x="70" y="-2" width="10" height="10"/>
           </children>
+          <children xmi:type="notation:Node" xmi:id="_mo73ANNbEe-1uL7-mHc_Jw" type="3012" element="_mn4HENNbEe-1uL7-mHc_Jw">
+            <children xmi:type="notation:Node" xmi:id="_mo-TQNNbEe-1uL7-mHc_Jw" visible="false" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_mo-TQdNbEe-1uL7-mHc_Jw" x="11"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_mpB9oNNbEe-1uL7-mHc_Jw" type="3005" element="_mn4HEdNbEe-1uL7-mHc_Jw">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_mpB9odNbEe-1uL7-mHc_Jw" fontName="Fira Code"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mpB9otNbEe-1uL7-mHc_Jw"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_mo73AdNbEe-1uL7-mHc_Jw" fontName="Fira Code" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mo73AtNbEe-1uL7-mHc_Jw" x="140" y="90" width="10" height="10"/>
+          </children>
           <styles xmi:type="notation:ShapeStyle" xmi:id="_aVQlcR4sEe2oAusR2-iOGg" fontName="Fira Code" fontHeight="8"/>
           <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aVQlch4sEe2oAusR2-iOGg" x="80" y="260" height="113"/>
         </children>
@@ -5222,6 +5233,17 @@
             </children>
             <styles xmi:type="notation:ShapeStyle" xmi:id="_adBvdh4uEe2oAusR2-iOGg" fontName="Fira Code" fontHeight="8"/>
             <layoutConstraint xmi:type="notation:Bounds" xmi:id="_adBvdx4uEe2oAusR2-iOGg" x="-2" y="60" width="10" height="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_mpCksNNbEe-1uL7-mHc_Jw" type="3012" element="_mn0csNNbEe-1uL7-mHc_Jw">
+            <children xmi:type="notation:Node" xmi:id="_mpCks9NbEe-1uL7-mHc_Jw" visible="false" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_mpCktNNbEe-1uL7-mHc_Jw" y="11"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_mpDLwNNbEe-1uL7-mHc_Jw" type="3005" element="_mn1DwNNbEe-1uL7-mHc_Jw">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_mpDLwdNbEe-1uL7-mHc_Jw" fontName="Fira Code"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mpDLwtNbEe-1uL7-mHc_Jw"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_mpCksdNbEe-1uL7-mHc_Jw" fontName="Fira Code" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mpCkstNbEe-1uL7-mHc_Jw" x="20" y="-2" width="10" height="10"/>
           </children>
           <styles xmi:type="notation:ShapeStyle" xmi:id="_dhlXgR4sEe2oAusR2-iOGg" fontName="Fira Code" fontHeight="8"/>
           <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dhlXgh4sEe2oAusR2-iOGg" x="380" y="260" height="83"/>
@@ -5627,6 +5649,22 @@
           <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Djedeh4xEe2oAusR2-iOGg" id="(0.5,0.5)"/>
           <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Djedex4xEe2oAusR2-iOGg" id="(0.5,0.5)"/>
         </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_mpFA8NNbEe-1uL7-mHc_Jw" type="4001" element="_mn7xcNNbEe-1uL7-mHc_Jw" source="_mpCksNNbEe-1uL7-mHc_Jw" target="_mo73ANNbEe-1uL7-mHc_Jw">
+          <children xmi:type="notation:Node" xmi:id="_mpFoANNbEe-1uL7-mHc_Jw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mpFoAdNbEe-1uL7-mHc_Jw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_mpFoAtNbEe-1uL7-mHc_Jw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mpFoA9NbEe-1uL7-mHc_Jw" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_mpFoBNNbEe-1uL7-mHc_Jw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mpFoBdNbEe-1uL7-mHc_Jw" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_mpFA8dNbEe-1uL7-mHc_Jw" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_mpFA8tNbEe-1uL7-mHc_Jw" fontColor="9914954" fontName="Fira Code" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mpFA89NbEe-1uL7-mHc_Jw" points="[-5, 2, 175, -90]$[-175, 89, 5, -3]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mpHdMNNbEe-1uL7-mHc_Jw" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mpHdMdNbEe-1uL7-mHc_Jw" id="(0.5,0.5)"/>
+        </edges>
       </data>
     </ownedAnnotationEntries>
     <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_TmgOcB4sEe2oAusR2-iOGg" source="DANNOTATION_CUSTOMIZATION_KEY">
@@ -5723,6 +5761,15 @@
         <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_acRhgR4uEe2oAusR2-iOGg"/>
         <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_acQ6cR4uEe2oAusR2-iOGg" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/OutFlowPort.png">
           <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.2/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
+      </ownedBorderedNodes>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_mn4HENNbEe-1uL7-mHc_Jw" name="CP 11" incomingEdges="_mn7xcNNbEe-1uL7-mHc_Jw" width="1" height="1">
+        <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#684d4388-3615-40a7-b81d-f97647294a67"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#684d4388-3615-40a7-b81d-f97647294a67"/>
+        <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_mn4uIdNbEe-1uL7-mHc_Jw"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_mn4HEdNbEe-1uL7-mHc_Jw" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/InFlowPort.png">
+          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.1/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
       </ownedBorderedNodes>
@@ -6064,6 +6111,15 @@
         </ownedStyle>
         <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
       </ownedBorderedNodes>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_mn0csNNbEe-1uL7-mHc_Jw" name="CP 19" outgoingEdges="_mn7xcNNbEe-1uL7-mHc_Jw" width="1" height="1">
+        <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#5269e15c-69fb-45fd-88a0-08d4ab5f5211"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#5269e15c-69fb-45fd-88a0-08d4ab5f5211"/>
+        <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_mn2R4NNbEe-1uL7-mHc_Jw"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_mn1DwNNbEe-1uL7-mHc_Jw" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/OutFlowPort.png">
+          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.2/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
+      </ownedBorderedNodes>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
       <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
       <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
@@ -6384,6 +6440,15 @@
         <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_Di_VQh4xEe2oAusR2-iOGg" labelColor="255,255,255"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Function']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_mn7xcNNbEe-1uL7-mHc_Jw" name="C 28" sourceNode="_mn0csNNbEe-1uL7-mHc_Jw" targetNode="_mn4HENNbEe-1uL7-mHc_Jw">
+      <target xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#f350dfd4-5997-4fab-b3d2-9a5214ae263c"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#f350dfd4-5997-4fab-b3d2-9a5214ae263c"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_mn8YgNNbEe-1uL7-mHc_Jw" targetArrow="NoDecoration" centered="Both" strokeColor="74,74,151">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']/@conditionnalStyles.3/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_mn8YgdNbEe-1uL7-mHc_Jw" labelColor="74,74,151"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']"/>
     </ownedDiagramElements>
     <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']"/>
     <currentConcern xmi:type="concern:ConcernDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@concerns/@ownedConcernDescriptions.0"/>

--- a/tests/data/ContextDiagram.aird
+++ b/tests/data/ContextDiagram.aird
@@ -110,7 +110,7 @@
         <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']"/>
         <target xmi:type="org.polarsys.capella.core.data.la:LogicalComponentPkg" href="ContextDiagram.capella#84c0978d-9a32-4f5b-8013-5b0b6adbfd73"/>
       </ownedRepresentationDescriptors>
-      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_TmNTgB4sEe2oAusR2-iOGg" name="[LAB] Stacking" repPath="#_TmJCEB4sEe2oAusR2-iOGg" changeId="728251a3-d435-453f-857b-9fb75e05bca7">
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_TmNTgB4sEe2oAusR2-iOGg" name="[LAB] Stacking" repPath="#_TmJCEB4sEe2oAusR2-iOGg" changeId="95e13f33-c912-4faa-8f90-6bbcb529351f">
         <eAnnotations xmi:type="description:DAnnotation" uid="_TmQ94B4sEe2oAusR2-iOGg" source="https://www.polarsys.org/capella/dannotation/DesactivatedFilters">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_TmQ94R4sEe2oAusR2-iOGg" key="hide.computed.component.exchanges.filter" value="true"/>
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_TmQ94h4sEe2oAusR2-iOGg" key="hide.computed.physical.links.filter" value="true"/>
@@ -5249,9 +5249,9 @@
             <children xmi:type="notation:Node" xmi:id="_HJf7A9NjEe-1uL7-mHc_Jw" visible="false" type="5010">
               <layoutConstraint xmi:type="notation:Location" xmi:id="_HJf7BNNjEe-1uL7-mHc_Jw" x="11"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_HJf7BdNjEe-1uL7-mHc_Jw" type="3005" element="_HItQ0dNjEe-1uL7-mHc_Jw">
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_HJf7BtNjEe-1uL7-mHc_Jw" fontName="Fira Code"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HJf7B9NjEe-1uL7-mHc_Jw"/>
+            <children xmi:type="notation:Node" xmi:id="_p91KsNNlEe-1uL7-mHc_Jw" type="3005" element="_p9U0b9NlEe-1uL7-mHc_Jw">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_p91KsdNlEe-1uL7-mHc_Jw" fontName="Fira Code"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_p91KstNlEe-1uL7-mHc_Jw"/>
             </children>
             <styles xmi:type="notation:ShapeStyle" xmi:id="_HJf7AdNjEe-1uL7-mHc_Jw" fontName="Fira Code" fontHeight="8"/>
             <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HJf7AtNjEe-1uL7-mHc_Jw" x="50" y="73" width="10" height="10"/>
@@ -5269,9 +5269,9 @@
             <children xmi:type="notation:Node" xmi:id="_HJgiE9NjEe-1uL7-mHc_Jw" visible="false" type="5010">
               <layoutConstraint xmi:type="notation:Location" xmi:id="_HJgiFNNjEe-1uL7-mHc_Jw" x="11"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_HJgiFdNjEe-1uL7-mHc_Jw" type="3005" element="_HIspwNNjEe-1uL7-mHc_Jw">
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_HJgiFtNjEe-1uL7-mHc_Jw" fontName="Fira Code"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HJgiF9NjEe-1uL7-mHc_Jw"/>
+            <children xmi:type="notation:Node" xmi:id="_pOA3UNNlEe-1uL7-mHc_Jw" type="3005" element="_pNhvKdNlEe-1uL7-mHc_Jw">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_pOA3UdNlEe-1uL7-mHc_Jw" fontName="Fira Code"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pOA3UtNlEe-1uL7-mHc_Jw"/>
             </children>
             <styles xmi:type="notation:ShapeStyle" xmi:id="_HJgiEdNjEe-1uL7-mHc_Jw" fontName="Fira Code" fontHeight="8"/>
             <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HJgiEtNjEe-1uL7-mHc_Jw" x="140" y="30" width="10" height="10"/>
@@ -6171,8 +6171,8 @@
         <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#ec443534-9c07-44be-96d7-802bfa32e67b"/>
         <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#ec443534-9c07-44be-96d7-802bfa32e67b"/>
         <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_HItQ09NjEe-1uL7-mHc_Jw"/>
-        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_HItQ0dNjEe-1uL7-mHc_Jw" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/InFlowPort.png">
-          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.1/@style"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_p9U0b9NlEe-1uL7-mHc_Jw" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/OutFlowPort.png">
+          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.2/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
       </ownedBorderedNodes>
@@ -6514,8 +6514,8 @@
         <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#ac7447ba-b89c-47f9-8390-d7db74c6e02c"/>
         <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#ac7447ba-b89c-47f9-8390-d7db74c6e02c"/>
         <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_HIspwtNjEe-1uL7-mHc_Jw"/>
-        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_HIspwNNjEe-1uL7-mHc_Jw" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/OutFlowPort.png">
-          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.2/@style"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_pNhvKdNlEe-1uL7-mHc_Jw" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/InFlowPort.png">
+          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.1/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
       </ownedBorderedNodes>

--- a/tests/data/ContextDiagram.aird
+++ b/tests/data/ContextDiagram.aird
@@ -110,7 +110,7 @@
         <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']"/>
         <target xmi:type="org.polarsys.capella.core.data.la:LogicalComponentPkg" href="ContextDiagram.capella#84c0978d-9a32-4f5b-8013-5b0b6adbfd73"/>
       </ownedRepresentationDescriptors>
-      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_TmNTgB4sEe2oAusR2-iOGg" name="[LAB] Stacking" repPath="#_TmJCEB4sEe2oAusR2-iOGg" changeId="75c9735c-2682-433b-b857-03d934e60551">
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_TmNTgB4sEe2oAusR2-iOGg" name="[LAB] Stacking" repPath="#_TmJCEB4sEe2oAusR2-iOGg" changeId="728251a3-d435-453f-857b-9fb75e05bca7">
         <eAnnotations xmi:type="description:DAnnotation" uid="_TmQ94B4sEe2oAusR2-iOGg" source="https://www.polarsys.org/capella/dannotation/DesactivatedFilters">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_TmQ94R4sEe2oAusR2-iOGg" key="hide.computed.component.exchanges.filter" value="true"/>
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_TmQ94h4sEe2oAusR2-iOGg" key="hide.computed.physical.links.filter" value="true"/>
@@ -5245,8 +5245,39 @@
             <styles xmi:type="notation:ShapeStyle" xmi:id="_mpCksdNbEe-1uL7-mHc_Jw" fontName="Fira Code" fontHeight="8"/>
             <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mpCkstNbEe-1uL7-mHc_Jw" x="20" y="-2" width="10" height="10"/>
           </children>
+          <children xmi:type="notation:Node" xmi:id="_HJf7ANNjEe-1uL7-mHc_Jw" type="3012" element="_HItQ0NNjEe-1uL7-mHc_Jw">
+            <children xmi:type="notation:Node" xmi:id="_HJf7A9NjEe-1uL7-mHc_Jw" visible="false" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_HJf7BNNjEe-1uL7-mHc_Jw" x="11"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_HJf7BdNjEe-1uL7-mHc_Jw" type="3005" element="_HItQ0dNjEe-1uL7-mHc_Jw">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_HJf7BtNjEe-1uL7-mHc_Jw" fontName="Fira Code"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HJf7B9NjEe-1uL7-mHc_Jw"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_HJf7AdNjEe-1uL7-mHc_Jw" fontName="Fira Code" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HJf7AtNjEe-1uL7-mHc_Jw" x="50" y="73" width="10" height="10"/>
+          </children>
           <styles xmi:type="notation:ShapeStyle" xmi:id="_dhlXgR4sEe2oAusR2-iOGg" fontName="Fira Code" fontHeight="8"/>
           <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dhlXgh4sEe2oAusR2-iOGg" x="380" y="260" height="83"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_F-_PsNNjEe-1uL7-mHc_Jw" type="2002" element="_F-OasNNjEe-1uL7-mHc_Jw">
+          <children xmi:type="notation:Node" xmi:id="_F-_Ps9NjEe-1uL7-mHc_Jw" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_F-_PtNNjEe-1uL7-mHc_Jw" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_F-_PtdNjEe-1uL7-mHc_Jw"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_F-_PttNjEe-1uL7-mHc_Jw"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_HJgiENNjEe-1uL7-mHc_Jw" type="3012" element="_HIsCsNNjEe-1uL7-mHc_Jw">
+            <children xmi:type="notation:Node" xmi:id="_HJgiE9NjEe-1uL7-mHc_Jw" visible="false" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_HJgiFNNjEe-1uL7-mHc_Jw" x="11"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_HJgiFdNjEe-1uL7-mHc_Jw" type="3005" element="_HIspwNNjEe-1uL7-mHc_Jw">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_HJgiFtNjEe-1uL7-mHc_Jw" fontName="Fira Code"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HJgiF9NjEe-1uL7-mHc_Jw"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_HJgiEdNjEe-1uL7-mHc_Jw" fontName="Fira Code" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HJgiEtNjEe-1uL7-mHc_Jw" x="140" y="30" width="10" height="10"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_F-_PsdNjEe-1uL7-mHc_Jw" fontName="Fira Code" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F-_PstNjEe-1uL7-mHc_Jw" x="180" y="440"/>
         </children>
         <styles xmi:type="notation:DiagramStyle" xmi:id="_TmQW0h4sEe2oAusR2-iOGg"/>
         <edges xmi:type="notation:Edge" xmi:id="_fyjUkB4sEe2oAusR2-iOGg" type="4001" element="_fxztsB4sEe2oAusR2-iOGg" source="_fyZjkB4sEe2oAusR2-iOGg" target="_fyiGcx4sEe2oAusR2-iOGg">
@@ -5664,6 +5695,22 @@
           <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mpFA89NbEe-1uL7-mHc_Jw" points="[-5, 2, 175, -90]$[-175, 89, 5, -3]"/>
           <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mpHdMNNbEe-1uL7-mHc_Jw" id="(0.5,0.5)"/>
           <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mpHdMdNbEe-1uL7-mHc_Jw" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_HJhJINNjEe-1uL7-mHc_Jw" type="4001" element="_HIt34NNjEe-1uL7-mHc_Jw" source="_HJgiENNjEe-1uL7-mHc_Jw" target="_HJf7ANNjEe-1uL7-mHc_Jw">
+          <children xmi:type="notation:Node" xmi:id="_HJhJJNNjEe-1uL7-mHc_Jw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HJhJJdNjEe-1uL7-mHc_Jw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_HJhJJtNjEe-1uL7-mHc_Jw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HJhJJ9NjEe-1uL7-mHc_Jw" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_HJhJKNNjEe-1uL7-mHc_Jw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HJhJKdNjEe-1uL7-mHc_Jw" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_HJhJIdNjEe-1uL7-mHc_Jw" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_HJhJItNjEe-1uL7-mHc_Jw" fontColor="9914954" fontName="Fira Code" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_HJhJI9NjEe-1uL7-mHc_Jw" points="[4, -5, -106, 132]$[105, -132, -5, 5]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HJhJKtNjEe-1uL7-mHc_Jw" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HJhJK9NjEe-1uL7-mHc_Jw" id="(0.5,0.5)"/>
         </edges>
       </data>
     </ownedAnnotationEntries>
@@ -6120,6 +6167,15 @@
         </ownedStyle>
         <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
       </ownedBorderedNodes>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_HItQ0NNjEe-1uL7-mHc_Jw" name="CP 20" incomingEdges="_HIt34NNjEe-1uL7-mHc_Jw" width="1" height="1">
+        <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#ec443534-9c07-44be-96d7-802bfa32e67b"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#ec443534-9c07-44be-96d7-802bfa32e67b"/>
+        <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_HItQ09NjEe-1uL7-mHc_Jw"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_HItQ0dNjEe-1uL7-mHc_Jw" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/InFlowPort.png">
+          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.1/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
+      </ownedBorderedNodes>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
       <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
       <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
@@ -6447,6 +6503,33 @@
       <ownedStyle xmi:type="diagram:EdgeStyle" uid="_mn8YgNNbEe-1uL7-mHc_Jw" targetArrow="NoDecoration" centered="Both" strokeColor="74,74,151">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']/@conditionnalStyles.3/@style"/>
         <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_mn8YgdNbEe-1uL7-mHc_Jw" labelColor="74,74,151"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_F-OasNNjEe-1uL7-mHc_Jw" name="Real leftie">
+      <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#22bf0991-c6cd-43dd-9129-9edff619c1bb"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="ContextDiagram.capella#22bf0991-c6cd-43dd-9129-9edff619c1bb"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalComponent" href="ContextDiagram.capella#3253a54d-6df2-4638-bd13-65e51c577758"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_HIsCsNNjEe-1uL7-mHc_Jw" name="CP 1" outgoingEdges="_HIt34NNjEe-1uL7-mHc_Jw" width="1" height="1">
+        <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#ac7447ba-b89c-47f9-8390-d7db74c6e02c"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="ContextDiagram.capella#ac7447ba-b89c-47f9-8390-d7db74c6e02c"/>
+        <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_HIspwtNjEe-1uL7-mHc_Jw"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_HIspwNNjEe-1uL7-mHc_Jw" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/OutFlowPort.png">
+          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.2/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_F-PBwNNjEe-1uL7-mHc_Jw" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="195,230,255" foregroundColor="150,177,218">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_HIt34NNjEe-1uL7-mHc_Jw" name="C 29" sourceNode="_HIsCsNNjEe-1uL7-mHc_Jw" targetNode="_HItQ0NNjEe-1uL7-mHc_Jw">
+      <target xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#fe3756df-2a89-45f3-91a3-0fc2e614afd0"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="ContextDiagram.capella#fe3756df-2a89-45f3-91a3-0fc2e614afd0"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_HIue8NNjEe-1uL7-mHc_Jw" targetArrow="NoDecoration" centered="Both" strokeColor="74,74,151">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']/@conditionnalStyles.3/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_HIue8dNjEe-1uL7-mHc_Jw" labelColor="74,74,151"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20DataFlow%20between%20Logical%20Components']"/>
     </ownedDiagramElements>

--- a/tests/data/ContextDiagram.capella
+++ b/tests/data/ContextDiagram.capella
@@ -4160,7 +4160,7 @@ The predator is far away</bodies>
                 id="5269e15c-69fb-45fd-88a0-08d4ab5f5211" name="CP 19" orientation="OUT"
                 kind="FLOW"/>
             <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
-                id="ec443534-9c07-44be-96d7-802bfa32e67b" name="CP 20" orientation="IN"
+                id="ec443534-9c07-44be-96d7-802bfa32e67b" name="CP 20" orientation="OUT"
                 kind="FLOW"/>
           </ownedLogicalComponents>
           <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
@@ -4484,7 +4484,7 @@ The predator is far away</bodies>
           <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
               id="3253a54d-6df2-4638-bd13-65e51c577758" name="Real leftie">
             <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
-                id="ac7447ba-b89c-47f9-8390-d7db74c6e02c" name="CP 1" orientation="OUT"
+                id="ac7447ba-b89c-47f9-8390-d7db74c6e02c" name="CP 1" orientation="IN"
                 kind="FLOW"/>
           </ownedLogicalComponents>
           <ownedLogicalComponentPkgs xsi:type="org.polarsys.capella.core.data.la:LogicalComponentPkg"

--- a/tests/data/ContextDiagram.capella
+++ b/tests/data/ContextDiagram.capella
@@ -62,7 +62,7 @@
                 definition="#682bd51d-5451-4930-a97e-8bfca6c3a127" value="true"/>
             <ownedAttributes xsi:type="Requirements:DateValueAttribute" id="b97c09b5-948a-46e8-a656-69d764ddce7d"
                 definition="#682bd51d-5451-4930-a97e-8bfca6c3a127" definitionProxy=""
-                value="2021-07-23T15:00:00.000+0200"/>
+                value="2021-07-23T13:00:00.000+0000"/>
             <ownedAttributes xsi:type="Requirements:IntegerValueAttribute" id="85dfd42c-7f6e-4236-a181-bdd784040431"
                 definition="#682bd51d-5451-4930-a97e-8bfca6c3a127" value="10"/>
             <ownedAttributes xsi:type="Requirements:RealValueAttribute" id="d2231d14-854d-4625-b48b-6cf1c2554367"
@@ -3727,6 +3727,15 @@ The predator is far away</bodies>
           <ownedComponentExchanges xsi:type="org.polarsys.capella.core.data.fa:ComponentExchange"
               id="fe3756df-2a89-45f3-91a3-0fc2e614afd0" name="C 29" source="#ac7447ba-b89c-47f9-8390-d7db74c6e02c"
               target="#ec443534-9c07-44be-96d7-802bfa32e67b" kind="FLOW"/>
+          <ownedComponentExchanges xsi:type="org.polarsys.capella.core.data.fa:ComponentExchange"
+              id="68212e30-0dcc-4b5f-83f2-0062f1feb1ba" name="Left to LC 2" source="#b24e2673-493c-4f43-9e37-619b35ac5452"
+              target="#5da72784-c5fe-4283-8832-218ecc1c6526" kind="FLOW"/>
+          <ownedComponentExchanges xsi:type="org.polarsys.capella.core.data.fa:ComponentExchange"
+              id="da4b0e27-8850-4358-97dd-90f4e032cf10" name="Right to Target" source="#34e4c983-e70a-424d-9ce4-858bd92cb925"
+              target="#4b0f396a-0f77-4675-a702-3575d67f6e05" kind="FLOW"/>
+          <ownedComponentExchanges xsi:type="org.polarsys.capella.core.data.fa:ComponentExchange"
+              id="58322776-25ab-42c7-93ee-44d37e8e7144" name="outer extended" source="#ed788945-9729-4d56-a1fa-0554bee65324"
+              target="#4f903b92-1748-42ff-be33-a95472e20d13" kind="FLOW"/>
           <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="a3194240-cd17-4998-8f8b-785233487ec3"
               name="Campus" abstractType="#6583b560-6d2f-4190-baa2-94eef179c8ea"/>
           <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
@@ -3798,6 +3807,12 @@ The predator is far away</bodies>
               name="LC 25" abstractType="#d6eb2818-656a-4a5b-b2f3-0792211fa6c0"/>
           <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="22bf0991-c6cd-43dd-9129-9edff619c1bb"
               name="Real leftie" abstractType="#3253a54d-6df2-4638-bd13-65e51c577758"/>
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="64f28085-f6dc-4141-8864-47c195423f04"
+              name="Parent LC" abstractType="#77b3349c-9184-478a-b005-893a4d789b47"/>
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="4e1f6130-335b-4e4b-87fa-91f31d72b927"
+              name="Left LC" abstractType="#d2eec5a9-1de4-44f5-bd99-60bab004f00c"/>
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="a939c41a-e8ca-4823-b317-775451b1817c"
+              name="Right LC" abstractType="#65622f9e-21af-4030-986e-bd4096e4f313"/>
           <ownedComponentRealizations xsi:type="org.polarsys.capella.core.data.cs:ComponentRealization"
               id="0f8b10b5-d460-4055-bd34-7e4a33e94b5e" targetElement="#230c4621-7e0a-4d0a-9db2-d4ba5e97b3df"
               sourceElement="#0d2edb8f-fa34-4e73-89ec-fb9a63001440"/>
@@ -4485,6 +4500,58 @@ The predator is far away</bodies>
               id="3253a54d-6df2-4638-bd13-65e51c577758" name="Real leftie">
             <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
                 id="ac7447ba-b89c-47f9-8390-d7db74c6e02c" name="CP 1" orientation="IN"
+                kind="FLOW"/>
+          </ownedLogicalComponents>
+          <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
+              id="77b3349c-9184-478a-b005-893a4d789b47" name="Parent LC">
+            <ownedComponentExchanges xsi:type="org.polarsys.capella.core.data.fa:ComponentExchange"
+                id="f9897b61-602d-4c18-a72d-f4521e7c094f" name="Target to LC 1" source="#138c1c84-713d-4567-9304-30364330b5a9"
+                target="#4b0f396a-0f77-4675-a702-3575d67f6e05" kind="FLOW"/>
+            <ownedComponentExchanges xsi:type="org.polarsys.capella.core.data.fa:ComponentExchange"
+                id="25f152df-7309-46d1-88ea-b34772c3eb34" name="inner extended" source="#386f8111-bd45-4bd0-a22b-b8f6c4b1216a"
+                target="#a662d5a2-beb0-469b-b947-f663ecf8f482" kind="FLOW"/>
+            <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="22881485-4989-49c0-8068-5af004d1db63"
+                name="Child LC 1" abstractType="#5694dff8-0645-4155-b836-7736a89f5c39"/>
+            <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="47cc117b-3760-470b-9474-0472d149d194"
+                name="Child LC 2" abstractType="#6a9d5145-d41d-4a28-a4fe-eb98b6f3da39"/>
+            <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+                id="4b0f396a-0f77-4675-a702-3575d67f6e05" name="CP 3" orientation="IN"
+                kind="FLOW"/>
+            <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
+                id="5694dff8-0645-4155-b836-7736a89f5c39" name="Child LC 1">
+              <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+                  id="138c1c84-713d-4567-9304-30364330b5a9" name="CP 1" orientation="OUT"
+                  kind="FLOW"/>
+              <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+                  id="386f8111-bd45-4bd0-a22b-b8f6c4b1216a" name="CP 2" orientation="OUT"
+                  kind="FLOW"/>
+            </ownedLogicalComponents>
+            <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
+                id="6a9d5145-d41d-4a28-a4fe-eb98b6f3da39" name="Child LC 2">
+              <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+                  id="5da72784-c5fe-4283-8832-218ecc1c6526" name="CP 1" orientation="IN"
+                  kind="FLOW"/>
+              <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+                  id="a662d5a2-beb0-469b-b947-f663ecf8f482" name="CP 2" orientation="IN"
+                  kind="FLOW"/>
+            </ownedLogicalComponents>
+          </ownedLogicalComponents>
+          <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
+              id="d2eec5a9-1de4-44f5-bd99-60bab004f00c" name="Left LC">
+            <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+                id="b24e2673-493c-4f43-9e37-619b35ac5452" name="CP 1" orientation="OUT"
+                kind="FLOW"/>
+            <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+                id="ed788945-9729-4d56-a1fa-0554bee65324" name="CP 2" orientation="OUT"
+                kind="FLOW"/>
+          </ownedLogicalComponents>
+          <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
+              id="65622f9e-21af-4030-986e-bd4096e4f313" name="Right LC">
+            <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+                id="34e4c983-e70a-424d-9ce4-858bd92cb925" name="CP 1" orientation="OUT"
+                kind="FLOW"/>
+            <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+                id="4f903b92-1748-42ff-be33-a95472e20d13" name="CP 2" orientation="IN"
                 kind="FLOW"/>
           </ownedLogicalComponents>
           <ownedLogicalComponentPkgs xsi:type="org.polarsys.capella.core.data.la:LogicalComponentPkg"

--- a/tests/data/ContextDiagram.capella
+++ b/tests/data/ContextDiagram.capella
@@ -3724,6 +3724,9 @@ The predator is far away</bodies>
           <ownedComponentExchanges xsi:type="org.polarsys.capella.core.data.fa:ComponentExchange"
               id="f350dfd4-5997-4fab-b3d2-9a5214ae263c" name="C 28" source="#5269e15c-69fb-45fd-88a0-08d4ab5f5211"
               target="#684d4388-3615-40a7-b81d-f97647294a67" kind="FLOW"/>
+          <ownedComponentExchanges xsi:type="org.polarsys.capella.core.data.fa:ComponentExchange"
+              id="fe3756df-2a89-45f3-91a3-0fc2e614afd0" name="C 29" source="#ac7447ba-b89c-47f9-8390-d7db74c6e02c"
+              target="#ec443534-9c07-44be-96d7-802bfa32e67b" kind="FLOW"/>
           <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="a3194240-cd17-4998-8f8b-785233487ec3"
               name="Campus" abstractType="#6583b560-6d2f-4190-baa2-94eef179c8ea"/>
           <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
@@ -3793,6 +3796,8 @@ The predator is far away</bodies>
               name="Cycle Parent" abstractType="#57bcce8e-e1fb-45dc-aaa1-4c5748b02b5d"/>
           <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="f6763b23-b5cc-491c-a428-a004cf9963fe"
               name="LC 25" abstractType="#d6eb2818-656a-4a5b-b2f3-0792211fa6c0"/>
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="22bf0991-c6cd-43dd-9129-9edff619c1bb"
+              name="Real leftie" abstractType="#3253a54d-6df2-4638-bd13-65e51c577758"/>
           <ownedComponentRealizations xsi:type="org.polarsys.capella.core.data.cs:ComponentRealization"
               id="0f8b10b5-d460-4055-bd34-7e4a33e94b5e" targetElement="#230c4621-7e0a-4d0a-9db2-d4ba5e97b3df"
               sourceElement="#0d2edb8f-fa34-4e73-89ec-fb9a63001440"/>
@@ -4154,6 +4159,9 @@ The predator is far away</bodies>
             <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
                 id="5269e15c-69fb-45fd-88a0-08d4ab5f5211" name="CP 19" orientation="OUT"
                 kind="FLOW"/>
+            <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+                id="ec443534-9c07-44be-96d7-802bfa32e67b" name="CP 20" orientation="IN"
+                kind="FLOW"/>
           </ownedLogicalComponents>
           <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
               id="16b4fcc5-548d-4721-b62a-d3d5b1c1d2eb" name="Hierarchy">
@@ -4472,6 +4480,12 @@ The predator is far away</bodies>
             <ownedFunctionalAllocation xsi:type="org.polarsys.capella.core.data.fa:ComponentFunctionalAllocation"
                 id="84fe724d-e9a7-4cda-b886-6e393e72d086" targetElement="#906e7244-3d1c-4787-8cfc-afc0efe02f06"
                 sourceElement="#d6eb2818-656a-4a5b-b2f3-0792211fa6c0"/>
+          </ownedLogicalComponents>
+          <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
+              id="3253a54d-6df2-4638-bd13-65e51c577758" name="Real leftie">
+            <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+                id="ac7447ba-b89c-47f9-8390-d7db74c6e02c" name="CP 1" orientation="OUT"
+                kind="FLOW"/>
           </ownedLogicalComponents>
           <ownedLogicalComponentPkgs xsi:type="org.polarsys.capella.core.data.la:LogicalComponentPkg"
               id="83d80c8a-e845-4fd9-bb6f-91fc32145785" name="LogicalComponents">

--- a/tests/data/ContextDiagram.capella
+++ b/tests/data/ContextDiagram.capella
@@ -3729,6 +3729,17 @@ The predator is far away</bodies>
           <ownedComponentExchanges xsi:type="org.polarsys.capella.core.data.fa:ComponentExchange"
               id="43158e15-f8d1-49e3-bc01-7222edcbf839" name="C 28" source="#f413a1aa-61d7-41d1-aa0b-60744965204f"
               target="#36fb9559-675b-4efd-87fd-b20aa893cd44" kind="FLOW"/>
+          <ownedComponentExchanges xsi:type="org.polarsys.capella.core.data.fa:ComponentExchange"
+              id="453903da-1cbd-4bb8-bab2-d83a825ee7d1" name="Left to Parent" source="#79780935-a7b3-4c2c-b664-67a9b2ce0d82"
+              target="#bcfc68d6-bce0-4281-9da5-eecd3ebc3025" kind="FLOW"/>
+          <ownedComponentExchanges xsi:type="org.polarsys.capella.core.data.fa:ComponentExchange"
+              id="d89b2b08-0061-4b43-9bd6-af829f80aa2f" name="Child 1 to Right 1"
+              source="#3f2c5aeb-6351-458f-a581-a5eaa0e2b07f" target="#6afd0810-6274-4bac-8092-d59a9ef9bd99"
+              kind="FLOW"/>
+          <ownedComponentExchanges xsi:type="org.polarsys.capella.core.data.fa:ComponentExchange"
+              id="6ba4f3d9-6adb-4632-817e-23d86b9b0637" name="Child 2 to Right 2"
+              source="#5fcfacff-479d-4ac0-a832-56396a07c1fe" target="#93f2fe63-cb60-4640-a1ab-d078b560a241"
+              kind="FLOW"/>
           <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="a3194240-cd17-4998-8f8b-785233487ec3"
               name="Campus" abstractType="#6583b560-6d2f-4190-baa2-94eef179c8ea"/>
           <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
@@ -3802,6 +3813,12 @@ The predator is far away</bodies>
               name="Parent" abstractType="#eb966300-e6a2-40b4-ab9c-98fa1d6d04ad"/>
           <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="11f75091-5849-48b3-b8bc-a660814944e9"
               name="LC 27" abstractType="#c6fd5f4e-f184-4a54-8320-f3bfd5ca7fdc"/>
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="48210457-d83d-45d7-b663-28c44a79e0fa"
+              name="Parent LC" abstractType="#fd69347c-fca9-4cdd-ae44-9182e13c8d9d"/>
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="debfa8e3-da1a-445f-b6c8-7d2ac5b5aeaf"
+              name="Right LC" abstractType="#b0a3a955-698f-4e66-8e71-599aa686290d"/>
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="04dcd5d0-2521-4d19-978a-443f63969a9c"
+              name="Left LC" abstractType="#9f7682b0-e830-4dd6-912b-0feb19ae0968"/>
           <ownedComponentRealizations xsi:type="org.polarsys.capella.core.data.cs:ComponentRealization"
               id="0f8b10b5-d460-4055-bd34-7e4a33e94b5e" targetElement="#230c4621-7e0a-4d0a-9db2-d4ba5e97b3df"
               sourceElement="#0d2edb8f-fa34-4e73-89ec-fb9a63001440"/>
@@ -4511,6 +4528,60 @@ The predator is far away</bodies>
               id="c6fd5f4e-f184-4a54-8320-f3bfd5ca7fdc" name="LC 27">
             <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
                 id="36fb9559-675b-4efd-87fd-b20aa893cd44" name="CP 1" orientation="IN"
+                kind="FLOW"/>
+          </ownedLogicalComponents>
+          <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
+              id="fd69347c-fca9-4cdd-ae44-9182e13c8d9d" name="Parent LC">
+            <ownedComponentExchanges xsi:type="org.polarsys.capella.core.data.fa:ComponentExchange"
+                id="955b6e5d-df64-4805-8973-93756a4be879" name="Parent to Child 1"
+                source="#ce221886-adfd-45f5-99cf-07baac99458d" target="#bcfc68d6-bce0-4281-9da5-eecd3ebc3025"
+                kind="FLOW"/>
+            <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="78b12b60-f134-48e4-8440-53e1b2b115c5"
+                name="Child LC 1" abstractType="#9f92e453-0692-4842-9e0c-4d36ab541acd"/>
+            <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="05f8fd0d-8fae-4d6d-b0d3-77428963d5c7"
+                name="Child LC 2" abstractType="#847991cf-546d-4817-b52f-a58b5a42d0e5"/>
+            <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+                id="bcfc68d6-bce0-4281-9da5-eecd3ebc3025" name="CP 3" orientation="IN"
+                kind="FLOW"/>
+            <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
+                id="9f92e453-0692-4842-9e0c-4d36ab541acd" name="Child LC 1">
+              <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+                  id="3f2c5aeb-6351-458f-a581-a5eaa0e2b07f" name="CP 1" orientation="OUT"
+                  kind="FLOW"/>
+              <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+                  id="ce221886-adfd-45f5-99cf-07baac99458d" name="CP 2" orientation="OUT"
+                  kind="FLOW"/>
+            </ownedLogicalComponents>
+            <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
+                id="847991cf-546d-4817-b52f-a58b5a42d0e5" name="Child LC 2">
+              <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+                  id="5fcfacff-479d-4ac0-a832-56396a07c1fe" name="CP 1" orientation="OUT"
+                  kind="FLOW"/>
+            </ownedLogicalComponents>
+          </ownedLogicalComponents>
+          <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
+              id="b0a3a955-698f-4e66-8e71-599aa686290d" name="Right LC">
+            <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="a059ee90-c181-4d9c-9705-a7cc40704242"
+                name="Right LC 1" abstractType="#fdbed138-965e-4abd-82f6-1dc794970fde"/>
+            <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="e2f83407-575c-42a1-8d82-7924ac0fb1f5"
+                name="Right LC 2" abstractType="#7fa21226-c6d0-418c-a061-cb38b207b852"/>
+            <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
+                id="fdbed138-965e-4abd-82f6-1dc794970fde" name="Right LC 1">
+              <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+                  id="6afd0810-6274-4bac-8092-d59a9ef9bd99" name="CP 1" orientation="IN"
+                  kind="FLOW"/>
+            </ownedLogicalComponents>
+            <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
+                id="7fa21226-c6d0-418c-a061-cb38b207b852" name="Right LC 2">
+              <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+                  id="93f2fe63-cb60-4640-a1ab-d078b560a241" name="CP 1" orientation="IN"
+                  kind="FLOW"/>
+            </ownedLogicalComponents>
+          </ownedLogicalComponents>
+          <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
+              id="9f7682b0-e830-4dd6-912b-0feb19ae0968" name="Left LC">
+            <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+                id="79780935-a7b3-4c2c-b664-67a9b2ce0d82" name="CP 1" orientation="OUT"
                 kind="FLOW"/>
           </ownedLogicalComponents>
           <ownedLogicalComponentPkgs xsi:type="org.polarsys.capella.core.data.la:LogicalComponentPkg"

--- a/tests/data/ContextDiagram.capella
+++ b/tests/data/ContextDiagram.capella
@@ -3721,6 +3721,9 @@ The predator is far away</bodies>
                 id="276e5728-52d2-4819-bb2f-b36cd0f35bd6" targetElement="#cb1e41b1-744b-43ea-89d2-d7c54dff4606"
                 sourceElement="#2f8ed849-fbda-4902-82ec-cbf8104ae686"/>
           </ownedComponentExchanges>
+          <ownedComponentExchanges xsi:type="org.polarsys.capella.core.data.fa:ComponentExchange"
+              id="f350dfd4-5997-4fab-b3d2-9a5214ae263c" name="C 28" source="#5269e15c-69fb-45fd-88a0-08d4ab5f5211"
+              target="#684d4388-3615-40a7-b81d-f97647294a67" kind="FLOW"/>
           <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="a3194240-cd17-4998-8f8b-785233487ec3"
               name="Campus" abstractType="#6583b560-6d2f-4190-baa2-94eef179c8ea"/>
           <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
@@ -4071,6 +4074,9 @@ The predator is far away</bodies>
               <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
                   id="60a1fd22-3ef8-46dd-8e0c-b4dbcca86ec0" name="CP 10" orientation="OUT"
                   kind="FLOW"/>
+              <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+                  id="684d4388-3615-40a7-b81d-f97647294a67" name="CP 11" orientation="IN"
+                  kind="FLOW"/>
             </ownedLogicalComponents>
           </ownedLogicalComponents>
           <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
@@ -4144,6 +4150,9 @@ The predator is far away</bodies>
                 kind="FLOW"/>
             <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
                 id="c06968be-09ae-4e9a-acc9-733c833a3c87" name="CP 18" orientation="IN"
+                kind="FLOW"/>
+            <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+                id="5269e15c-69fb-45fd-88a0-08d4ab5f5211" name="CP 19" orientation="OUT"
                 kind="FLOW"/>
           </ownedLogicalComponents>
           <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"

--- a/tests/test_context_diagrams.py
+++ b/tests/test_context_diagrams.py
@@ -12,7 +12,6 @@ TEST_ACTOR_SIZING_UUID = "6c8f32bf-0316-477f-a23b-b5239624c28d"
 TEST_HIERARCHY_UUID = "16b4fcc5-548d-4721-b62a-d3d5b1c1d2eb"
 TEST_HIERARCHY_PARENTS_UUIDS = {
     "0d2edb8f-fa34-4e73-89ec-fb9a63001440",
-    "99a1d711-74af-4db7-af08-4dbd91c281ce",
     "53558f58-270e-4206-8fc7-3cf9e788fac9",
 }
 TEST_ACTIVITY_UUIDS = {
@@ -126,8 +125,8 @@ def test_context_diagrams_rerender_on_parameter_change(
         pytest.param(
             [
                 ("e1e48763-7479-4f3a-8134-c82bb6705d58", 112, 187),
-                ("8df45b70-15cc-4d3a-99e4-593516392c5a", 154, 234),
-                ("74af6883-25a0-446a-80f3-656f8a490b11", 266, 412),
+                ("8df45b70-15cc-4d3a-99e4-593516392c5a", 140, 234),
+                ("74af6883-25a0-446a-80f3-656f8a490b11", 252, 412),
             ],
             id="LogicalComponent",
         ),
@@ -275,7 +274,7 @@ def test_context_diagram_hide_direct_children(
     }
 
     diag = obj.context_diagram
-    grey = diag.render("svgdiagram", blackbox=True).save(pretty=True)
+    grey = diag.render(None, blackbox=True)
     diag.invalidate_cache()
     white = diag.render(None, blackbox=False)
 
@@ -309,21 +308,16 @@ def test_context_diagram_display_unused_ports(
 def test_context_diagram_blackbox(
     model: capellambse.MelodyModel,
 ) -> None:
-    obj = model.by_uuid("77b3349c-9184-478a-b005-893a4d789b47")
+    obj = model.by_uuid("fd69347c-fca9-4cdd-ae44-9182e13c8d9d")
     hidden_element_uuids = {
-        "22881485-4989-49c0-8068-5af004d1db63",
-        "138c1c84-713d-4567-9304-30364330b5a9",
-        "386f8111-bd45-4bd0-a22b-b8f6c4b1216a",
-        "f9897b61-602d-4c18-a72d-f4521e7c094f",
-        "25f152df-7309-46d1-88ea-b34772c3eb34",
-        "a662d5a2-beb0-469b-b947-f663ecf8f482",
-        "47cc117b-3760-470b-9474-0472d149d194",
+        "9f92e453-0692-4842-9e0c-4d36ab541acd",
+        "847991cf-546d-4817-b52f-a58b5a42d0e5",
+        "955b6e5d-df64-4805-8973-93756a4be879",
+        "ce221886-adfd-45f5-99cf-07baac99458d",
     }
 
     white = obj.context_diagram.render(None, blackbox=False)
-    black = obj.context_diagram.render("svgdiagram", blackbox=True).save(
-        pretty=True
-    )
+    black = obj.context_diagram.render(None, blackbox=True)
 
     assert {element.uuid for element in white} & hidden_element_uuids
     assert not {element.uuid for element in black} & hidden_element_uuids

--- a/tests/test_context_diagrams.py
+++ b/tests/test_context_diagrams.py
@@ -123,7 +123,7 @@ def test_context_diagrams_rerender_on_parameter_change(
         ),
         pytest.param(
             [
-                ("e1e48763-7479-4f3a-8134-c82bb6705d58", 126, 190),
+                ("e1e48763-7479-4f3a-8134-c82bb6705d58", 112, 187),
                 ("8df45b70-15cc-4d3a-99e4-593516392c5a", 154, 234),
                 ("74af6883-25a0-446a-80f3-656f8a490b11", 266, 412),
             ],
@@ -131,8 +131,8 @@ def test_context_diagrams_rerender_on_parameter_change(
         ),
         pytest.param(
             [
-                ("0c06cc88-8c77-46f2-8542-c08b1e8edd18", 112, 168),
-                ("9f1e1875-9ead-4af2-b428-c390786a436a", 112, 168),
+                ("0c06cc88-8c77-46f2-8542-c08b1e8edd18", 98, 164),
+                ("9f1e1875-9ead-4af2-b428-c390786a436a", 98, 164),
             ],
             id="LogicalFunction",
         ),
@@ -140,7 +140,7 @@ def test_context_diagrams_rerender_on_parameter_change(
             [
                 ("6241d0c5-65d2-4c0b-b79c-a2a8ed7273f6", 36, 36),
                 ("344a405e-c7e5-4367-8a9a-41d3d9a27f81", 40, 40),
-                ("230c4621-7e0a-4d0a-9db2-d4ba5e97b3df", 42, 60),
+                ("230c4621-7e0a-4d0a-9db2-d4ba5e97b3df", 42, 49),
             ],
             id="SystemComponent Root",
         ),

--- a/tests/test_context_diagrams.py
+++ b/tests/test_context_diagrams.py
@@ -273,9 +273,9 @@ def test_context_diagram_hide_direct_children(
     }
 
     diag = obj.context_diagram
-    grey = diag.render(None, hide_direct_children=True)
+    grey = diag.render("svgdiagram", blackbox=True).save(pretty=True)
     diag.invalidate_cache()
-    white = diag.render(None, hide_direct_children=False)
+    white = diag.render(None, blackbox=False)
 
     assert not {element.uuid for element in grey} & expected_hidden_uuids
     assert {element.uuid for element in white} & expected_hidden_uuids
@@ -302,3 +302,26 @@ def test_context_diagram_display_unused_ports(
 
     assert unused_port_uuid not in {element.uuid for element in adiag}
     assert unused_port_uuid in {element.uuid for element in bdiag}
+
+
+def test_context_diagram_blackbox(
+    model: capellambse.MelodyModel,
+) -> None:
+    obj = model.by_uuid("77b3349c-9184-478a-b005-893a4d789b47")
+    hidden_element_uuids = {
+        "22881485-4989-49c0-8068-5af004d1db63",
+        "138c1c84-713d-4567-9304-30364330b5a9",
+        "386f8111-bd45-4bd0-a22b-b8f6c4b1216a",
+        "f9897b61-602d-4c18-a72d-f4521e7c094f",
+        "25f152df-7309-46d1-88ea-b34772c3eb34",
+        "a662d5a2-beb0-469b-b947-f663ecf8f482",
+        "47cc117b-3760-470b-9474-0472d149d194",
+    }
+
+    white = obj.context_diagram.render(None, blackbox=False)
+    black = obj.context_diagram.render("svgdiagram", blackbox=True).save(
+        pretty=True
+    )
+
+    assert {element.uuid for element in white} & hidden_element_uuids
+    assert not {element.uuid for element in black} & hidden_element_uuids


### PR DESCRIPTION
- collects target's children's context for context diagram (resolves #176)
- exchanges between context components are collected (display_actor_relation)
- blackbox view (resolves #177)
- fixes edge routing