### PR TITLE
fix: Port spread not correct for equal case

### DIFF
--- a/src/capellambse_context_diagrams/collectors/exchanges.py
+++ b/src/capellambse_context_diagrams/collectors/exchanges.py
@@ -152,7 +152,7 @@ class InterfaceContextCollector(ExchangeCollector):
 
             port_spread = len(self.outgoing_edges) - len(self.incoming_edges)
             _port_spread = len(self.incoming_edges) - len(self.outgoing_edges)
-            if port_spread <= _port_spread:
+            if port_spread < _port_spread:
                 self.incoming_edges, self.outgoing_edges = (
                     self.outgoing_edges,
                     self.incoming_edges,


### PR DESCRIPTION
When outgoing and incoming edges are the same, the direction shouldn't be reversed.