### PR TITLE
Use correct download URL for binaries

### DIFF
--- a/src/capellambse_context_diagrams/_elkjs.py
+++ b/src/capellambse_context_diagrams/_elkjs.py
@@ -344,7 +344,7 @@ class ELKManager:
         package_version = importlib.metadata.version(
             "capellambse_context_diagrams"
         )
-        url = f"https://github.com/DSD-DBS/capellambse-context-diagrams/releases/tag/v{package_version}/{self.binary_name}"
+        url = f"https://github.com/DSD-DBS/capellambse-context-diagrams/releases/download/v{package_version}/{self.binary_name}"
         response = requests.get(url)
         response.raise_for_status()
         with open(self.binary_path, "wb") as f:


### PR DESCRIPTION
Interestingly, the bad URL isn't a 404 (which would raise an exception right then and there), but just serves the release details page instead. This HTML then gets written out as if it's the binary, which causes an error when later trying to `exec()` it.