### PR TITLE
Inline the assertion into the ELK comparison test helper

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,10 +146,10 @@ def write_layout_test_data_file(
 
 def compare_elk_input_data(
     data: _elkjs.ELKInputData, expected: _elkjs.ELKInputData
-) -> bool:
-    return data.model_dump(exclude_defaults=True) == expected.model_dump(
-        exclude_defaults=True
-    )
+) -> None:
+    data_dump = data.model_dump(exclude_defaults=True)
+    expected_dump = expected.model_dump(exclude_defaults=True)
+    assert data_dump == expected_dump
 
 
 @mock.patch("capellambse.helpers.extent_func", text_size_mocker)

--- a/tests/test_cable_tree_views.py
+++ b/tests/test_cable_tree_views.py
@@ -54,7 +54,7 @@ def test_collecting(
         model, params, TEST_CABLE_TREE_DATA_ROOT, "cable_tree"
     )
 
-    assert compare_elk_input_data(result, expected)
+    compare_elk_input_data(result, expected)
 
 
 @pytest.mark.parametrize("params", TEST_SET)

--- a/tests/test_context_diagrams.py
+++ b/tests/test_context_diagrams.py
@@ -329,7 +329,7 @@ class TestContextDiagrams:
             model, params, TEST_CONTEXT_DATA_ROOT, "context_diagram"
         )
 
-        assert compare_elk_input_data(result, expected)
+        compare_elk_input_data(result, expected)
 
     @staticmethod
     @pytest.mark.parametrize("params", TEST_CONTEXT_SET)

--- a/tests/test_dataflow_views.py
+++ b/tests/test_dataflow_views.py
@@ -51,7 +51,7 @@ def test_collecting(
         model, params, TEST_DATA_FLOW_DATA_ROOT, "data_flow_view"
     )
 
-    assert compare_elk_input_data(result, expected)
+    compare_elk_input_data(result, expected)
 
 
 @pytest.mark.parametrize("params", TEST_DATA_FLOW_SET)

--- a/tests/test_interface_diagrams.py
+++ b/tests/test_interface_diagrams.py
@@ -136,7 +136,7 @@ class TestInterfaceDiagrams:
             model, params, TEST_INTERFACE_DATA_ROOT, "context_diagram"
         )
 
-        assert compare_elk_input_data(result, expected)
+        compare_elk_input_data(result, expected)
 
     @staticmethod
     @pytest.mark.parametrize("params", TEST_INTERFACE_SET)

--- a/tests/test_realization_views.py
+++ b/tests/test_realization_views.py
@@ -43,11 +43,8 @@ def test_collecting(
     expected_edges_file = TEST_REALIZATION_DATA_ROOT / (
         file_path.stem + "_edges.json"
     )
-    expected_edges = expected_edges_file.read_text(encoding="utf8")
-
-    def extra_assert(edges, expected_edges) -> bool:
-        edges_list = [edge.model_dump(exclude_defaults=True) for edge in edges]
-        return json.loads(expected_edges) == {"edges": edges_list}
+    expected_text = expected_edges_file.read_text(encoding="utf8")
+    expected_edges = json.loads(expected_text)["edges"]
 
     (result, edges), expected = generic_collecting_test(
         model,
@@ -56,8 +53,10 @@ def test_collecting(
         "realization_view",
     )
 
-    assert compare_elk_input_data(result, expected)
-    assert extra_assert(edges, expected_edges)
+    compare_elk_input_data(result, expected)
+
+    actual_edges = [edge.model_dump(exclude_defaults=True) for edge in edges]
+    assert actual_edges == expected_edges
 
 
 @pytest.mark.parametrize("params", TEST_REALIZATION_SET)

--- a/tests/test_tree_views.py
+++ b/tests/test_tree_views.py
@@ -38,7 +38,7 @@ def test_collecting(
         model, params, TEST_TREE_DATA_ROOT, "tree_view"
     )
 
-    assert compare_elk_input_data(result, expected)
+    compare_elk_input_data(result, expected)
     assert legend.model_dump(exclude_defaults=True) == json.loads(
         expected_legend
     )


### PR DESCRIPTION
Rewrite ELK input comparison test helper to assert equality directly, instead of returning a bool that gets asserted later.

This gives pytest better insight into the asserted data, enabling it to perform its magic assertion rewrites and enrich the test output. As such, this is most noticable when increasing verbosity with invocations like `pytest -vv`.