### PR TITLE
Bump minimum supported Pydantic version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
           - mkdocs
           - mkdocs-gen-files
           - mkdocs-literate-nav
-          - pydantic==2.7.3
+          - pydantic==2.8.0
           - pytest
           - types-setuptools
           - types-requests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 dependencies = [
   "capellambse>=0.6.6,<0.7",
   "typing_extensions",
-  "pydantic>=2.7.3",
+  "pydantic>=2.8.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
When running type checks under pre-commit, the declared dependencies are normally installed using the default Python interpreter, so they must be compatible with it. Pydantic started supporting Python 3.13 with v2.8.0.

Bump the minimum supported version, and thus the version that we type-check against, to ensure compatibility with Python 3.13.