### PR TITLE
Extend accepted capellambse version range to include v0.7.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "capellambse>=0.6.6,<0.7",
+  "capellambse>=0.6.6,<0.8",
   "typing_extensions",
   "pydantic>=2.8.0",
 ]


### PR DESCRIPTION
capellambse's CI currently needs a compatible context-diagrams release (on PyPI) for some of the checks. v0.7.0 is compatible with the current context-diagrams version, so it's safe to simply extend the range.