### PR TITLE
ci: Fixate deno to v2.3.6

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: "2.x"
+          deno-version: "2.3.6"
       - name: Run unit tests
         run: uv run pytest -n auto
 
@@ -105,7 +105,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: "2.x"
+          deno-version: "2.3.6"
       - name: Build for Windows x64
         run: |
           deno compile --target x86_64-pc-windows-msvc --allow-read --allow-net \
@@ -145,7 +145,6 @@ jobs:
             elk-${{ github.ref_name }}-aarch64-apple-darwin
             elk-${{ github.ref_name }}-x86_64-unknown-linux-gnu
             elk-${{ github.ref_name }}-aarch64-unknown-linux-gnu
-
 
   pypi:
     name: Publish to PyPI

--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -13,8 +13,8 @@ build:
   jobs:
     create_environment:
       - asdf plugin-add deno https://github.com/asdf-community/asdf-deno.git
-      - asdf install deno latest
-      - asdf global deno latest
+      - asdf install deno 2.3.6
+      - asdf global deno 2.3.6
       - asdf plugin add uv
       - asdf install uv latest
       - asdf global uv latest


### PR DESCRIPTION
New deno v2.3.7 doesn't work. The process can't be started. Sad dino.
@zusorio :t-rex: 