### PR TITLE
Properly clean up stdin/out/err handles of the elk.js helper

### DIFF
--- a/src/capellambse_context_diagrams/_elkjs.py
+++ b/src/capellambse_context_diagrams/_elkjs.py
@@ -375,7 +375,6 @@ class ELKManager:
             [self.binary_path],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
             text=True,
             bufsize=1,
         )
@@ -408,7 +407,6 @@ class ELKManager:
             ],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
             text=True,
             bufsize=1,
         )
@@ -440,7 +438,13 @@ class ELKManager:
     def terminate_process(self) -> None:
         log.debug("Terminating elk.js helper process")
         if self._proc is not None:
+            assert self._proc.stdin is not None
+            assert self._proc.stdout is not None
+            assert self._proc.stderr is None
+            self._proc.stdin.close()
             self._proc.terminate()
+            self._proc.wait(30)
+            self._proc.stdout.close()
             self._proc = None
             log.debug("Terminated elk.js helper process")
         else:


### PR DESCRIPTION
This fixes ResourceWarnings about unclosed files when terminating the helper process, for example during interpreter shutdown.

To verify, run the following command[^1]:

[^1]: The additional `python` flags are needed to make the warnings visible, as the `ResourceWarning` category is ignored by default.

```sh
python -Xtracemalloc -Xdev -Walways -c '__import__("capellambse").loadcli("ife-demo").by_uuid("dab8526e-cf3a-4c8a-8fa1-7df4aa281bcf").context_diagram.render("svg")'
```

On current master, you will see the following warnings:

```
/usr/lib/python3.13/subprocess.py:1140: ResourceWarning: subprocess 37807 is still running
  _warn("subprocess %s is still running" % self.pid,
Object allocated at (most recent call last):
  File ".../src/capellambse_context_diagrams/_elkjs.py", lineno 398
    self._proc = subprocess.Popen(
.../src/capellambse_context_diagrams/_elkjs.py:443: ResourceWarning: unclosed file <_io.TextIOWrapper name=4 encoding='UTF-8'>
  self._proc = None
Object allocated at (most recent call last):
  File "/usr/lib/python3.13/subprocess.py", lineno 1025
    self.stdin = io.TextIOWrapper(self.stdin, write_through=True,
.../src/capellambse_context_diagrams/_elkjs.py:443: ResourceWarning: unclosed file <_io.TextIOWrapper name=5 encoding='UTF-8'>
  self._proc = None
Object allocated at (most recent call last):
  File "/usr/lib/python3.13/subprocess.py", lineno 1031
    self.stdout = io.TextIOWrapper(self.stdout,
```

After applying this PR, these warnings will be gone.