### PR TITLE
Update ruff config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ extend-select = [
   "UP",     # pyupgrade
   "YTT",    # flake8-2020
 ]
-extend-ignore = [
+ignore = [
   "D1",      # Missing docstring in _
   "D201",    # No blank lines allowed before function docstring  # auto-formatting
   "D202",    # No blank lines allowed after function docstring  # auto-formatting


### PR DESCRIPTION
`tool.ruff.lint.extend-ignore` is deprecated in favor of `.ignore` (which defaults to empty, so we aren't accidentally overwriting any defaults here).

Docs: https://docs.astral.sh/ruff/settings/#lint_extend-ignore
See-also: https://github.com/dbinfrago/py-capellambse/issues/593