### PR TITLE
Run capella-polarion downstream tests during PRs

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -164,3 +164,37 @@ jobs:
           path: dist/
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  downstream-tests:
+    name: Run downstream tests in ${{matrix.repo}}
+    runs-on: ubuntu-latest
+    needs: [build]
+    strategy:
+      fail-fast: false
+      matrix:
+        repo:
+          - dbinfrago/capella-polarion
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          filter: tree:0
+          repository: ${{matrix.repo}}
+      - uses: actions/download-artifact@v5
+        with:
+          path: dist/
+          name: python-package-distributions
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "**/pyproject.toml"
+          python-version: "3.13"
+      - run: |-
+          echo SETUPTOOLS_SCM_PRETEND_VERSION="$(
+            uvx --with setuptools_scm python -c \
+              "import setuptools_scm as scm; print(scm.get_version())"
+          )" >> "$GITHUB_ENV"
+      - run: uv add --dev ./dist/*.whl pytest pytest-xdist && uv sync
+      - run: uv run pytest -n auto


### PR DESCRIPTION
The idea is the same as in capellambse: Find out as soon as possible when downstream users of the library are going to break. The actions configuration is the same too, with minor adjustments for the slightly different build environment.